### PR TITLE
fix(database): implement missing expression operators

### DIFF
--- a/src/implementations/database/expression.ts
+++ b/src/implementations/database/expression.ts
@@ -140,15 +140,15 @@ export class Expression {
   stage_bit_or = "$bitOr";
   stage_bit_xor = "$bitXor";
   stage_bit_not = "$bitNot";
-  stage_bit_lshift() {
+  stage_bit_lshift(shift: unknown) {
     return {
-      $multiply: [this.value, { $pow: [2, this.currentStage!.args[0]] }],
+      $multiply: [this.value, { $pow: [2, shift] }],
     };
   }
-  stage_bit_rshift() {
+  stage_bit_rshift(shift: unknown) {
     return {
       $floor: {
-        $divide: [this.value, { $pow: [2, this.currentStage!.args[0]] }],
+        $divide: [this.value, { $pow: [2, shift] }],
       },
     };
   }
@@ -256,8 +256,7 @@ export class Expression {
       },
     };
   }
-  stage_obj_has() {
-    const fields = this.currentStage!.args[0] as string[];
+  stage_obj_has(fields: unknown) {
     const keys = {
       $map: {
         input: { $objectToArray: this.value },

--- a/src/implementations/database/expression.ts
+++ b/src/implementations/database/expression.ts
@@ -112,8 +112,8 @@ export class Expression {
   stage_date_tod() {
     return {
       $add: [
-        { $mul: [{ $hour: this.value }, 3600] },
-        { $mul: [{ $minute: this.value }, 60] },
+        { $multiply: [{ $hour: this.value }, 3600] },
+        { $multiply: [{ $minute: this.value }, 60] },
         { $second: this.value },
       ],
     };
@@ -140,8 +140,18 @@ export class Expression {
   stage_bit_or = "$bitOr";
   stage_bit_xor = "$bitXor";
   stage_bit_not = "$bitNot";
-  stage_bit_lshift = "$bit_lshift"; // TODO: should we keep bitshifts? { $multiply: [value, { $pow: [2, arg] }], }
-  stage_bit_rshift = "$bit_rshift";
+  stage_bit_lshift() {
+    return {
+      $multiply: [this.value, { $pow: [2, this.currentStage!.args[0]] }],
+    };
+  }
+  stage_bit_rshift() {
+    return {
+      $floor: {
+        $divide: [this.value, { $pow: [2, this.currentStage!.args[0]] }],
+      },
+    };
+  }
 
   stage_cmp_gt = "$gt";
   stage_cmp_ge = "$gte";
@@ -155,7 +165,7 @@ export class Expression {
     }
     return split;
   }
-  stage_str_concat = "$add";
+  stage_str_concat = "$concat";
   stage_str_upcase = "$toUpper";
   stage_str_downcase = "$toLower";
   stage_str_len = "$strLenCP";
@@ -218,7 +228,8 @@ export class Expression {
     const index =
       typeof this.value === "string" &&
       typeof key === "string" &&
-      this.value.startsWith("$")
+      this.value.startsWith("$") &&
+      !key.startsWith("$")
         ? `${this.value}.${key}`
         : { $getField: { field: key, input: this.value } };
     if (def) {
@@ -245,5 +256,15 @@ export class Expression {
       },
     };
   }
-  //stage_obj_has = '$obj_has'; // TODO: generate big condition?
+  stage_obj_has() {
+    const fields = this.currentStage!.args[0] as string[];
+    const keys = {
+      $map: {
+        input: { $objectToArray: this.value },
+        as: "temporary_entry",
+        in: "$$temporary_entry.k",
+      },
+    };
+    return { $setIsSubset: [fields, keys] };
+  }
 }


### PR DESCRIPTION
## Summary
- Implement bitshift operators (`blshift`, `brshift`) via `$multiply`/`$divide` with `$pow`
- Implement string `concat` via `$concat` (was incorrectly mapped to `$add`)
- Implement `hasfields` via `$setIsSubset` on `$objectToArray` keys
- Implement `timeofday` via hour/minute/second arithmetic

## Test plan
- Tests are in the companion PR on AntelopeJS/interface-database
- All 202 interface-database tests pass with these changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR implements four previously missing/stub expression operators in the MongoDB aggregation expression translator. All previously flagged P1 issues (raw undecoded args in lshift/rshift and obj_has) have been resolved. The only remaining finding is a P2 suggestion about wrapping bitshift results in `$toLong` to preserve integer semantics.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the one remaining finding is a P2 suggestion about wrapping bitshift results in `$toLong` and does not affect correctness for typical integer inputs.

All previously flagged P1 issues (raw undecoded args in lshift/rshift and obj_has) have been resolved. The only open comment is a P2 style suggestion about preserving integer types in the bitshift operators via `$toLong`, which does not break existing tests.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/implementations/database/expression.ts | Implements four missing operators: fixes `$mul`→`$multiply` in `stage_date_tod`, adds `stage_bit_lshift`/`stage_bit_rshift` via `$multiply`/`$divide` with `$pow` (result is float, not integer), fixes `stage_str_concat` from `$add`→`$concat`, adds `stage_obj_has` via `$setIsSubset`, and guards `stage_obj_index` against dollar-prefixed keys. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[addStages loop] --> B{callback type}
    B -- string --> C["{ [op]: [this.value, ...decodedArgs] }"]
    B -- function --> D[decode all args via DecodeValue]
    D --> E{stage}
    E -- stage_bit_lshift --> F["$multiply: [value, $pow: [2, shift]]"]
    E -- stage_bit_rshift --> G["$floor: $divide: [value, $pow: [2, shift]]"]
    E -- stage_str_concat --> H["$concat: [value, ...args]"]
    E -- stage_obj_has --> I["$setIsSubset: [fields, $map objectToArray keys]"]
    E -- stage_date_tod --> J["$add: [$multiply hour*3600, $multiply min*60, $second]"]
    E -- stage_obj_index --> K{key starts with $?}
    K -- yes --> L["$getField fallback"]
    K -- no --> M["dot notation: value.key"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/implementations/database/expression.ts
Line: 143-154

Comment:
**`$pow` returns a float, not an integer**

`$multiply` / `$pow` produces a 64-bit float (e.g., `5 << 3` → `40.0` instead of `40`). This means the shift result cannot be piped directly into the native bitwise operators (`$bitAnd`, `$bitOr`, etc.) which require `Int32` or `Long`, and may cause unexpected type coercion further down a pipeline. Consider wrapping the result in `$toLong` or `$toInt` to preserve integer semantics.

```suggestion
  stage_bit_lshift(shift: unknown) {
    return {
      $toLong: {
        $multiply: [this.value, { $pow: [2, shift] }],
      },
    };
  }
  stage_bit_rshift(shift: unknown) {
    return {
      $toLong: {
        $floor: {
          $divide: [this.value, { $pow: [2, shift] }],
        },
      },
    };
  }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(database): use decoded args in bitsh..."](https://github.com/antelopejs/mongodb/commit/1e10b70e057d224b4e2f37723ffe101f84ed36c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27171898)</sub>

<!-- /greptile_comment -->