### PR TITLE
fix(database): detect compound index field order changes on init

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -88,9 +88,10 @@ async function InitializeDatabase(
       const existingByFields = indexesByFields[fieldsKey];
 
       if (existingByName) {
+        const existingKeys = Object.keys(existingByName.key);
         const nameFieldsMatch =
-          Object.keys(existingByName.key).length === fields.length &&
-          fields.every((field) => existingByName.key[field]);
+          existingKeys.length === fields.length &&
+          fields.every((field, i) => existingKeys[i] === field);
         if (nameFieldsMatch) {
           continue;
         }


### PR DESCRIPTION
## Summary

`InitializeDatabase` in `src/connection.ts` compared an existing named index against the declared spec using `fields.every((field) => existingByName.key[field])`, which only checks that each declared field is **present** in the index key. For compound indexes this ignores field **order** — `{a:1, b:1, c:1}` and `{c:1, b:1, a:1}` are two different physical indexes in MongoDB, but the check treated them as equivalent.

Consequence: a consumer who changes the order of `@Index({ group: 'name' })` decorators (or their property declaration order, depending on how the metadata is collected) to fix a compound sort will see their TS declaration update, but the physical index in Mongo keeps the previous ordering. `orderBy(indexName, dir)` then emits a `$sort` the existing index cannot serve, and the planner falls back to another index or a sort-in-memory — the resulting order no longer matches the declared field priority.

## Fix

Compare position-by-position against `Object.keys(existingByName.key)`, so a reordering is detected and takes the existing drop-and-recreate branch (unchanged). Field name set and field count checks are preserved.

## Context

Surfaced in a downstream project migrated from RethinkDB to MongoDB: a compound index `[season_order, order, DateModified]` had been declared in a different order pre-migration, the TS declaration was corrected in a follow-up commit, but the physical index never changed on restart — so public listings silently sorted primarily by `DateModified` instead of the intended `season_order`.

## Test plan

- [ ] Manual: declare a compound index, start the module against a fresh Mongo, change the field order in code, restart, verify `db.<col>.getIndexes()` reflects the new order.
- [ ] Manual: confirm that a rename-only change (same fields in the same order) still short-circuits (no drop, no recreate).
- [ ] `pnpm run build` (passes locally)
- [ ] `pnpm run lint` (no new warnings introduced by this change; 6 pre-existing `noNonNullAssertion` warnings in other files remain)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a silent correctness bug in `InitializeDatabase` where compound index field order changes were not detected on restart. The old `fields.every((field) => existingByName.key[field])` was a set-membership test; the new `fields.every((field, i) => existingKeys[i] === field)` checks position-by-position, so a reordering now correctly triggers the existing drop-and-recreate path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is minimal, correct, and addresses a real silent bug with no regressions introduced.

Single-file, focused change that replaces a set-membership check with a positional check. Logic is sound: the length guard is preserved, and fields.every((field, i) => existingKeys[i] === field) correctly detects any reordering or field substitution. No new issues observed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/connection.ts | Fixes compound index field order comparison in InitializeDatabase — now checks field names positionally rather than as a set, correctly detecting reordering and triggering drop-and-recreate. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[For each declared index] --> B{existingByName found?}
    B -- Yes --> C[existingKeys = Object.keys of existing key doc]
    C --> D{Length matches AND every field matches positionally?}
    D -- Match --> E[continue, no change needed]
    D -- Mismatch --> F[dropIndex by name]
    F --> G[createIndex with new field order]
    B -- No --> H{existingByFields found?}
    H -- Yes --> E
    H -- No --> G
```

<sub>Reviews (1): Last reviewed commit: ["fix(database): detect compound index fie..."](https://github.com/antelopejs/mongodb/commit/07eb31899cec70722b21e4221c6a8e293aa1e338) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29155836)</sub>

<!-- /greptile_comment -->