### PR TITLE
fix(database): preserve literal dotted keys in update()

### DIFF
--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -168,7 +168,13 @@ export class SelectionQuery extends AggregationPipeline {
       update: (doc) => ({
         updateOne: {
           filter: { _id: doc._id },
-          update: { $set: doc },
+          update: [
+            {
+              $replaceWith: {
+                $mergeObjects: ["$$ROOT", { $literal: doc }],
+              },
+            },
+          ],
           upsert: true,
         },
       }),
@@ -185,17 +191,53 @@ export class SelectionQuery extends AggregationPipeline {
     return documents.map((doc) => doc._id);
   }
 
+  private isAggregationOperator(
+    value: unknown,
+  ): value is Record<string, unknown> {
+    return (
+      value !== null &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      Object.getPrototypeOf(value) === Object.prototype &&
+      Object.keys(value as object).some((k) => k.startsWith("$"))
+    );
+  }
+
+  private hasExpression(value: unknown): boolean {
+    if (typeof value === "string") return value.startsWith("$");
+    if (value === null || typeof value !== "object") return false;
+    if (Array.isArray(value)) return value.some((v) => this.hasExpression(v));
+    if (Object.getPrototypeOf(value) !== Object.prototype) return false;
+    if (this.isAggregationOperator(value)) return true;
+    return Object.values(value as object).some((v) => this.hasExpression(v));
+  }
+
+  private literalizeUpdateValue(value: unknown): unknown {
+    if (!this.hasExpression(value)) return { $literal: value };
+    if (typeof value === "string") return value;
+    if (Array.isArray(value)) {
+      return value.map((v) => this.literalizeUpdateValue(v));
+    }
+    if (this.isAggregationOperator(value)) return value;
+    return {
+      $arrayToObject: [
+        Object.entries(value as object).map(([k, v]) => [
+          k,
+          this.literalizeUpdateValue(v),
+        ]),
+      ],
+    };
+  }
+
   private async update() {
     const collection = await GetCollection(this.database, this.collection);
-    const isExpression =
-      typeof this._newValue === "string" ||
-      (typeof this._newValue === "object" &&
-        this._newValue !== null &&
-        Object.keys(this._newValue).some((k) => k.startsWith("$")));
-    const updatePipeline = isExpression
-      ? [{ $replaceWith: this._newValue }]
-      : [{ $set: this._newValue }];
-    const res = await collection.updateMany(this.getFilter(), updatePipeline);
+    const res = await collection.updateMany(this.getFilter(), [
+      {
+        $replaceWith: {
+          $mergeObjects: ["$$ROOT", this.literalizeUpdateValue(this._newValue)],
+        },
+      },
+    ]);
     return res.modifiedCount;
   }
 


### PR DESCRIPTION
## Summary
- `update()` previously built `[{ $set: _newValue }]` (aggregation `$set`), which parses keys as field paths and rejects legacy data containing literal dots, e.g. `{ iot_device_safemodes: { 'states.channel.1': 80 } }`.
- Switched to `$replaceWith: { $mergeObjects: ["$$ROOT", literalize(_newValue)] }`. A new recursive `literalizeUpdateValue` wraps pure-data subtrees in `$literal` (preserving dots at any depth) and rebuilds mixed subtrees via `$arrayToObject` so dotted field names survive while inner `$`-operators still evaluate.
- Applied the same idiom to `insertWithConflict()`'s `"update"` mode, which had the identical bug at the second site.
- Folded the old top-level `$replaceWith`-vs-merge branching into the recursive helper. `update()` now always merges into `$$ROOT`, matching its name; deep `$`-prefixed strings continue to evaluate as paths (matching the pre-fix aggregation `$set` behavior).

## Test plan
- [ ] CI / `pnpm run test` — full module suite (202 tests) passes, including the three `Update with expression (numeric|single selection|mixed)` cases that confirm value-side aggregation operators still evaluate.
- [ ] Manual smoke against a copy of the affected `iot_device_safemodes` document: the failing legacy operation now succeeds and the dotted key round-trips intact.
- [ ] Follow-up: the sibling `@antelopejs/interface-database` test suite has new local cases covering literal dot-keys (top-level + insert-conflict-update) and a depth-2 expression regression. They land separately when that package is released.

## Behavior change
Anyone previously using top-level dot-keys to perform nested-path updates (e.g. `update({ 'profile.name': 'John' })`) will now see a literal top-level field named `profile.name`. Migration: pass nested objects (`update({ profile: { name: 'John' } })`). This brings `update()` in line with `replace()`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes dotted-key corruption in `update()` and `insertWithConflict(\"update\")` by replacing `$set` / top-level `$replaceWith` with an aggregation-pipeline merge that wraps pure-data subtrees in `$literal` and reconstructs mixed subtrees via `$arrayToObject`.

- The `$arrayToObject` expression in `literalizeUpdateValue` is constructed as `{ $arrayToObject: [ pairsArray ] }` (one-element wrapper array) instead of the required `{ $arrayToObject: pairsArray }`, so any update whose value mixes literal fields with aggregation-expression values will produce a MongoDB error at runtime.

<h3>Confidence Score: 3/5</h3>

Not safe to merge — the `$arrayToObject` bug will cause runtime errors for mixed-expression updates.

One P1 defect found: the spurious extra `[…]` in the `$arrayToObject` construction makes every mixed-expression update path fail with a MongoDB error. The pure-literal path (`$literal`) and the `insertWithConflict` change look correct, but the broken branch is exactly what the PR intends to exercise.

src/implementations/database/selection.ts — specifically the `literalizeUpdateValue` method's `$arrayToObject` branch (lines 222–229).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/implementations/database/selection.ts | Adds `literalizeUpdateValue` to preserve dotted keys via `$literal`/`$arrayToObject`, and switches `update()` + `insertWithConflict` "update" mode to aggregation-pipeline merges — but the `$arrayToObject` expression is wrapped in a spurious extra array, making mixed-expression updates fail at runtime. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["update(_newValue)"] --> B["literalizeUpdateValue(value)"]
    B --> C{hasExpression?}
    C -- "No" --> D["{ $literal: value }"]
    C -- "Yes" --> E{typeof string?}
    E -- "Yes" --> F["return value as-is\n(e.g. '$fieldRef')"]
    E -- "No" --> G{Array.isArray?}
    G -- "Yes" --> H["recurse each element"]
    G -- "No" --> I{isAggregationOperator?}
    I -- "Yes" --> J["return operator as-is\n(e.g. { $add:[...] })"]
    I -- "No" --> K["{ $arrayToObject:\n  ⚠️ [pairsArray] }\n(should be pairsArray directly)"]
    D & F & H & J & K --> L["$mergeObjects: ['$$ROOT', result]"]
    L --> M["$replaceWith → updateMany"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/implementations/database/selection.ts:222-229
**`$arrayToObject` receives a doubly-nested array**

`Object.entries(…).map(…)` already produces the pairs array `[["k1", v1], ["k2", v2], …]`. Wrapping it in a second `[…]` gives `$arrayToObject` a **one-element array whose single element is the pairs array** — i.e. `{ $arrayToObject: [[[k1,v1],[k2,v2]]] }` — which MongoDB rejects as invalid. This branch is hit whenever an object mixes literal fields with aggregation-expression values, so mixed-expression updates will always throw at runtime.

```suggestion
    return {
      $arrayToObject: Object.entries(value as object).map(([k, v]) => [
        k,
        this.literalizeUpdateValue(v),
      ]),
    };
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(database): preserve literal dotted k..."](https://github.com/antelopejs/mongodb/commit/44cc85476298f6fb70a0e15f308213e2c2640ed3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30316541)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->