### PR TITLE
feat(database): adopt interface-database 0.1.0 with physical store and tenant scoping

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@antelopejs/interface-core": "^0.0.2",
-    "@antelopejs/interface-database": "^0.0.3",
+    "@antelopejs/interface-database": "^0.1.0",
     "@antelopejs/interface-mongodb": "^0.0.2",
     "chai": "^4.5.0",
     "mongodb": "^6.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       '@antelopejs/interface-database':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.1.0
+        version: 0.1.0
       '@antelopejs/interface-mongodb':
         specifier: ^0.0.2
         version: 0.0.2(socks@2.8.7)
@@ -78,8 +78,11 @@ packages:
   '@antelopejs/interface-core@0.0.2':
     resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
 
-  '@antelopejs/interface-database@0.0.3':
-    resolution: {integrity: sha512-JVoD7E2H+B51UkL1nwB+KgaDb4+Z6THqNTBJEnJu7MjfR3c2xIYVLru36puPfRmYe47t3sMgrkjhpJgR5R1BPg==}
+  '@antelopejs/interface-core@0.0.3':
+    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
+
+  '@antelopejs/interface-database@0.1.0':
+    resolution: {integrity: sha512-6r+f5A6fttYrQyUh7NnRJxOaNjgsKpb3CeROIQGB7z5EB1vsxgOji8X3CBXflZeEIPlueMuw+YKv1e5+LE6hDg==}
 
   '@antelopejs/interface-mongodb@0.0.2':
     resolution: {integrity: sha512-5ZmObFrF74sVDSHwhNTQhQe7sEm2yneucrZtdtrCDfdnTIuKP07AJ4CNhGBZ7pSBk9ok0tk12i3MTCYx/40MHA==}
@@ -1449,9 +1452,13 @@ snapshots:
     dependencies:
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-database@0.0.3':
+  '@antelopejs/interface-core@0.0.3':
     dependencies:
-      '@antelopejs/interface-core': 0.0.2
+      reflect-metadata: 0.2.2
+
+  '@antelopejs/interface-database@0.1.0':
+    dependencies:
+      '@antelopejs/interface-core': 0.0.3
 
   '@antelopejs/interface-mongodb@0.0.2(socks@2.8.7)':
     dependencies:

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6,12 +6,8 @@ import {
   type MongoClientOptions,
 } from "mongodb";
 
-export function buildDatabaseName(
-  schemaId: string,
-  instanceId: string | undefined,
-): string {
-  return instanceId !== undefined ? `${schemaId}-${instanceId}` : schemaId;
-}
+const TENANT_ID_FIELD = "tenant_id";
+const TENANT_ID_INDEX = "tenant_id";
 
 export async function Connect(url: string, options?: MongoClientOptions) {
   await Disconnect();
@@ -55,88 +51,82 @@ export interface IndexDefinition {
 
 export interface TableDefinition {
   indexes: Record<string, IndexDefinition>;
+  tenantScoped?: boolean;
 }
 
 export interface SchemaDefinition {
   [tableName: string]: TableDefinition;
 }
 
-async function InitializeDatabase(
+async function ensureCollection(
   db: Db,
-  schema: SchemaDefinition,
-  rowLevel?: boolean,
+  tableId: string,
+  existingCollections: Set<string>,
 ) {
+  if (!existingCollections.has(tableId)) {
+    await db.createCollection(tableId);
+  }
+}
+
+async function syncSecondaryIndexes(
+  collection: Collection,
+  table: TableDefinition,
+) {
+  const existingIndexes = await collection.indexes();
+  const indexesByName = Object.fromEntries(
+    existingIndexes.map((index) => [index.name, index]),
+  );
+  const indexesByFields = Object.fromEntries(
+    existingIndexes.map((index) => [Object.keys(index.key).join(","), index]),
+  );
+  for (const [indexId, index] of Object.entries(table.indexes)) {
+    const fields = index.fields ?? [indexId];
+    const fieldsKey = fields.join(",");
+    const existingByName = indexesByName[indexId];
+    const existingByFields = indexesByFields[fieldsKey];
+
+    if (existingByName) {
+      const existingKeys = Object.keys(existingByName.key);
+      const nameFieldsMatch =
+        existingKeys.length === fields.length &&
+        fields.every((field, i) => existingKeys[i] === field);
+      if (nameFieldsMatch) {
+        continue;
+      }
+      await collection.dropIndex(indexId);
+    } else if (existingByFields) {
+      continue;
+    }
+    await collection.createIndex(fields, { name: indexId });
+  }
+}
+
+async function ensureTenantIndex(collection: Collection) {
+  const existingIndexes = await collection.indexes();
+  const hasTenantIndex = existingIndexes.some(
+    (index) =>
+      index.name === TENANT_ID_INDEX ||
+      (Object.keys(index.key).length === 1 && index.key[TENANT_ID_FIELD]),
+  );
+  if (!hasTenantIndex) {
+    await collection.createIndex([TENANT_ID_FIELD], { name: TENANT_ID_INDEX });
+  }
+}
+
+export async function InitializeSchemaInPhysicalStore(
+  physicalStore: string,
+  schema: SchemaDefinition,
+) {
+  const db = await GetDatabase(physicalStore);
   const existingCollections = new Set(
     (await db.listCollections().toArray()).map((collection) => collection.name),
   );
   for (const [tableId, table] of Object.entries(schema)) {
-    if (!existingCollections.has(tableId)) {
-      await db.createCollection(tableId);
-    }
+    await ensureCollection(db, tableId, existingCollections);
     const collection = db.collection(tableId);
-    const existingIndexes = await collection.indexes();
-    const indexesByName = Object.fromEntries(
-      existingIndexes.map((index) => [index.name, index]),
-    );
-    const indexesByFields = Object.fromEntries(
-      existingIndexes.map((index) => [Object.keys(index.key).join(","), index]),
-    );
-    for (const [indexId, index] of Object.entries(table.indexes)) {
-      const fields = index.fields ?? [indexId];
-      const fieldsKey = fields.join(",");
-      const existingByName = indexesByName[indexId];
-      const existingByFields = indexesByFields[fieldsKey];
-
-      if (existingByName) {
-        const existingKeys = Object.keys(existingByName.key);
-        const nameFieldsMatch =
-          existingKeys.length === fields.length &&
-          fields.every((field, i) => existingKeys[i] === field);
-        if (nameFieldsMatch) {
-          continue;
-        }
-        await collection.dropIndex(indexId);
-      } else if (existingByFields) {
-        continue;
-      }
-      await collection.createIndex(fields, { name: indexId });
-    }
-    if (rowLevel) {
-      const hasTenantIndex = existingIndexes.some(
-        (index) =>
-          index.name === "tenant_id" ||
-          (Object.keys(index.key).length === 1 && index.key.tenant_id),
-      );
-      if (!hasTenantIndex) {
-        await collection.createIndex(["tenant_id"], { name: "tenant_id" });
-      }
+    await syncSecondaryIndexes(collection, table);
+    if (table.tenantScoped) {
+      await ensureTenantIndex(collection);
     }
   }
-}
-
-export async function CreateRowLevelDatabase(
-  schemaId: string,
-  schema: SchemaDefinition,
-) {
-  const db = await GetDatabase(schemaId);
-  await InitializeDatabase(db, schema, true);
-}
-
-export async function CreateSchemaInstance(
-  schemaId: string,
-  instanceId: string | undefined,
-  schema: SchemaDefinition,
-) {
-  const dbName = buildDatabaseName(schemaId, instanceId);
-  const db = await GetDatabase(dbName);
-  await InitializeDatabase(db, schema);
-}
-
-export async function DestroySchemaInstance(
-  schemaId: string,
-  instanceId: string | undefined,
-) {
-  const dbName = buildDatabaseName(schemaId, instanceId);
-  const db = await GetDatabase(dbName);
-  await db.dropDatabase();
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -5,8 +5,8 @@ import {
   MongoClient,
   type MongoClientOptions,
 } from "mongodb";
+import { TENANT_ID_FIELD } from "./implementations/database/utils";
 
-const TENANT_ID_FIELD = "tenant_id";
 const TENANT_ID_INDEX = "tenant_id";
 
 export async function Connect(url: string, options?: MongoClientOptions) {

--- a/src/implementations/database/pipeline.ts
+++ b/src/implementations/database/pipeline.ts
@@ -103,10 +103,6 @@ export class AggregationPipeline {
         this.context.withRoot(`$$${tmpRoot}`),
       );
 
-      if (this.isCrossDatabase(rightStream)) {
-        return this.crossDatabaseSubquery(subQuery, rightStream);
-      }
-
       // Check if the FK value is a $map variable ($$temporary_*).
       // $lookup pipeline can't access $map variables — they only exist
       // during expression evaluation, not at pipeline stage level.
@@ -192,9 +188,6 @@ export class AggregationPipeline {
     if (this.wrappedObject) {
       const wrappedObject = this.wrappedObject;
       result = result.map((element: any) => element[wrappedObject]);
-    }
-    if (this.crossDatabaseLookups.length > 0) {
-      await this.resolveCrossDatabaseLookups(result);
     }
     if (this.singleElement) {
       return result.length > 0 ? result[0] : this.reductionDefault;
@@ -325,103 +318,6 @@ export class AggregationPipeline {
       this.setRoot(DefaultConstant(`$${this.wrappedObject}`, defaultValue));
     }
     return this;
-  }
-
-  private crossDatabaseLookups: Array<{
-    fkField: string;
-    matchField: string;
-    database: string;
-    collection: string;
-    singleElement: boolean;
-  }> = [];
-
-  /**
-   * Handle cross-database sub-queries via post-processing in run().
-   * MongoDB Community Edition does not support {db, coll} in $lookup.
-   * We record the FK field info, keep the original value in the document,
-   * then after run() batch-query the foreign DB and replace FK values.
-   */
-  private async crossDatabaseSubquery(
-    subQuery: QueryStage[],
-    rightStream: AggregationPipeline,
-  ) {
-    const getStage = subQuery.find(
-      (s) => s.stage === "get" || s.stage === "getAll",
-    );
-    const matchField =
-      getStage?.stage === "get" ? "_id" : (getStage?.options?.index ?? "_id");
-
-    // Decode the FK expression to find the field path (e.g. "$$ROOT.user_id" or "$_wrapped.user_id")
-    const fkExpr = getStage?.args?.[0]
-      ? await DecodeValue(getStage.args[0], this.context)
-      : null;
-
-    if (!fkExpr || typeof fkExpr !== "string") {
-      return null;
-    }
-
-    // Extract the field name from the expression (e.g. "$$ROOT.user_id" -> "user_id")
-    const fkField = fkExpr.includes(".")
-      ? fkExpr.split(".").pop()!
-      : fkExpr.replace(/^\$+/, "");
-
-    this.crossDatabaseLookups.push({
-      fkField,
-      matchField,
-      database: rightStream.database,
-      collection: rightStream.collection,
-      singleElement: rightStream.singleElement,
-    });
-
-    // Return the original FK value expression so the merge is a no-op for this field
-    return fkExpr;
-  }
-
-  private async resolveCrossDatabaseLookups(results: any[]) {
-    for (const lookup of this.crossDatabaseLookups) {
-      // Collect unique FK values from all results
-      const fkValues = [
-        ...new Set(
-          results
-            .map((r) => r[lookup.fkField])
-            .filter((v) => v != null && typeof v !== "object"),
-        ),
-      ];
-      if (fkValues.length === 0) continue;
-
-      // Batch query the foreign collection
-      const foreignCollection = await GetCollection(
-        lookup.database,
-        lookup.collection,
-      );
-      const foreignDocs = await foreignCollection
-        .find({ [lookup.matchField]: { $in: fkValues } })
-        .toArray();
-      const foreignMap = new Map(
-        foreignDocs.map((doc) => [String(doc[lookup.matchField]), doc]),
-      );
-
-      // Replace FK values with resolved documents
-      for (const row of results) {
-        const fkValue = row[lookup.fkField];
-        if (fkValue != null && typeof fkValue !== "object") {
-          const resolved = foreignMap.get(String(fkValue));
-          row[lookup.fkField] = lookup.singleElement
-            ? (resolved ?? null)
-            : resolved
-              ? [resolved]
-              : [];
-        }
-      }
-    }
-  }
-
-  private isCrossDatabase(rightStream: AggregationPipeline): boolean {
-    return (
-      this.database !== "$ARG" &&
-      rightStream.database !== "$ARG" &&
-      rightStream.database !== this.database
-    );
   }
 
   private flushPendingUnset() {

--- a/src/implementations/database/pipeline.ts
+++ b/src/implementations/database/pipeline.ts
@@ -92,6 +92,18 @@ export class AggregationPipeline {
 
   private pendingUnset: string[] = [];
 
+  private assertSamePhysicalStore(rightStream: AggregationPipeline) {
+    if (
+      this.database !== "$ARG" &&
+      rightStream.database !== "$ARG" &&
+      rightStream.database !== this.database
+    ) {
+      throw new Error(
+        `Cross-physical-store subquery not supported: '${this.database}' → '${rightStream.database}'. Co-locate the schemas via SchemaOptions.physicalStore or perform the lookup in application code.`,
+      );
+    }
+  }
+
   public async addStages(stages: QueryStage[]) {
     const oldSubquery = this.context.subquery;
     this.context.subquery = async (subQuery) => {
@@ -102,6 +114,7 @@ export class AggregationPipeline {
         subQuery,
         this.context.withRoot(`$$${tmpRoot}`),
       );
+      this.assertSamePhysicalStore(rightStream);
 
       // Check if the FK value is a $map variable ($$temporary_*).
       // $lookup pipeline can't access $map variables — they only exist
@@ -424,6 +437,7 @@ export class AggregationPipeline {
       this.context,
     );
     assert(rightStream instanceof AggregationPipeline);
+    this.assertSamePhysicalStore(rightStream);
 
     if (this.wrappedObject !== rightStream.wrappedObject) {
       if (!this.wrappedObject) {
@@ -454,6 +468,7 @@ export class AggregationPipeline {
     const predicate = stage.args[1];
     const mapper = stage.args[2];
     assert(rightStream instanceof AggregationPipeline);
+    this.assertSamePhysicalStore(rightStream);
     const root = this.getRoot();
     const tmp = Temporary("join");
     this.pipeline.push(
@@ -496,6 +511,7 @@ export class AggregationPipeline {
       this.context,
     );
     assert(rightStream instanceof SelectionQuery);
+    this.assertSamePhysicalStore(rightStream);
 
     const localField = this.getField(stage.options.localKey);
     const foreignField = stage.options.otherKey;

--- a/src/implementations/database/schema.ts
+++ b/src/implementations/database/schema.ts
@@ -16,7 +16,7 @@ function ownershipKey(physicalStore: string, tableName: string): string {
   return `${physicalStore}\0${tableName}`;
 }
 
-function assertOwnership(
+function claimOwnership(
   physicalStore: string,
   tableName: string,
   schemaId: string,
@@ -31,18 +31,39 @@ function assertOwnership(
   collectionOwnership.set(key, schemaId);
 }
 
+function rollbackRegistration(
+  schemaId: string,
+  physicalStore: string,
+  claimedTables: string[],
+) {
+  for (const tableName of claimedTables) {
+    const key = ownershipKey(physicalStore, tableName);
+    if (collectionOwnership.get(key) === schemaId) {
+      collectionOwnership.delete(key);
+    }
+  }
+  delete existingSchemas[schemaId];
+}
+
 export const Schemas = {
   async register(
     schemaId: string,
     schema: SchemaDefinition,
     options: SchemaOptions,
   ) {
-    existingSchemas[schemaId] = { definition: schema, options };
     const physicalStore = options.physicalStore ?? schemaId;
-    for (const tableName of Object.keys(schema)) {
-      assertOwnership(physicalStore, tableName, schemaId);
+    existingSchemas[schemaId] = { definition: schema, options };
+    const claimed: string[] = [];
+    try {
+      for (const tableName of Object.keys(schema)) {
+        claimOwnership(physicalStore, tableName, schemaId);
+        claimed.push(tableName);
+      }
+      await InitializeSchemaInPhysicalStore(physicalStore, schema);
+    } catch (err) {
+      rollbackRegistration(schemaId, physicalStore, claimed);
+      throw err;
     }
-    await InitializeSchemaInPhysicalStore(physicalStore, schema);
   },
   unregister(schemaId: string) {
     const entry = existingSchemas[schemaId];

--- a/src/implementations/database/schema.ts
+++ b/src/implementations/database/schema.ts
@@ -3,19 +3,33 @@ import type {
   SchemaDefinition,
   SchemaOptions,
 } from "@antelopejs/interface-database/schema";
-import {
-  CreateRowLevelDatabase,
-  CreateSchemaInstance,
-  DestroySchemaInstance,
-} from "../../connection";
+import { InitializeSchemaInPhysicalStore } from "../../connection";
 
-export const existingSchemas: Record<
+const existingSchemas: Record<
   string,
   { definition: SchemaDefinition; options: SchemaOptions }
 > = {};
-export const existingInstances: Record<string, Set<string>> = {};
 
-// TODO: watch changes to db to update existingInstances
+const collectionOwnership = new Map<string, string>();
+
+function ownershipKey(physicalStore: string, tableName: string): string {
+  return `${physicalStore}\0${tableName}`;
+}
+
+function assertOwnership(
+  physicalStore: string,
+  tableName: string,
+  schemaId: string,
+) {
+  const key = ownershipKey(physicalStore, tableName);
+  const owner = collectionOwnership.get(key);
+  if (owner && owner !== schemaId) {
+    throw new Error(
+      `Collection '${tableName}' in physical store '${physicalStore}' is already declared by schema '${owner}', cannot redeclare in '${schemaId}'`,
+    );
+  }
+  collectionOwnership.set(key, schemaId);
+}
 
 export const Schemas = {
   async register(
@@ -24,22 +38,30 @@ export const Schemas = {
     options: SchemaOptions,
   ) {
     existingSchemas[schemaId] = { definition: schema, options };
-    if (!existingInstances[schemaId]) {
-      existingInstances[schemaId] = new Set<string>();
+    const physicalStore = options.physicalStore ?? schemaId;
+    for (const tableName of Object.keys(schema)) {
+      assertOwnership(physicalStore, tableName, schemaId);
     }
-    if (!options.rowLevel) {
-      return;
-    }
-    await CreateRowLevelDatabase(schemaId, schema);
+    await InitializeSchemaInPhysicalStore(physicalStore, schema);
   },
   unregister(schemaId: string) {
+    const entry = existingSchemas[schemaId];
+    if (entry) {
+      const physicalStore = entry.options.physicalStore ?? schemaId;
+      for (const tableName of Object.keys(entry.definition)) {
+        const key = ownershipKey(physicalStore, tableName);
+        if (collectionOwnership.get(key) === schemaId) {
+          collectionOwnership.delete(key);
+        }
+      }
+    }
     delete existingSchemas[schemaId];
-    delete existingInstances[schemaId];
   },
 };
 
-export function IsRowLevel(schemaId: string): boolean {
-  return existingSchemas[schemaId]?.options?.rowLevel === true;
+export function GetPhysicalStore(schemaId: string): string {
+  assert(schemaId in existingSchemas, `Unknown schema '${schemaId}'`);
+  return existingSchemas[schemaId].options.physicalStore ?? schemaId;
 }
 
 export function GetSchema(schemaId: string) {
@@ -51,6 +73,10 @@ export function GetTable(schemaId: string, tableId: string) {
   const schema = GetSchema(schemaId);
   assert(tableId in schema);
   return schema[tableId];
+}
+
+export function IsTenantScoped(schemaId: string, tableId: string): boolean {
+  return GetTable(schemaId, tableId).tenantScoped === true;
 }
 
 export function GetIndex(
@@ -66,48 +92,4 @@ export function GetIndex(
     assert(!onlyIndex);
     return { fields: [indexId] };
   }
-}
-
-export function IsValidInstance(
-  schemaId: string,
-  instanceId: string | undefined,
-) {
-  assert(schemaId in existingInstances);
-  if (IsRowLevel(schemaId)) {
-    if (instanceId === undefined) {
-      throw new Error(`Row-level schema '${schemaId}' requires a tenant ID`);
-    }
-    return true;
-  }
-  const instances = existingInstances[schemaId];
-  return instances.has(instanceId ?? "");
-}
-
-export async function CreateInstance(
-  schemaId: string,
-  instanceId: string | undefined,
-) {
-  if (IsRowLevel(schemaId)) {
-    return;
-  }
-  const schema = GetSchema(schemaId);
-  const instances = existingInstances[schemaId];
-  instances.add(instanceId ?? "");
-  await CreateSchemaInstance(schemaId, instanceId, schema);
-}
-
-export async function DestroyInstance(
-  schemaId: string,
-  instanceId: string | undefined,
-) {
-  if (IsRowLevel(schemaId)) {
-    return;
-  }
-  assert(schemaId in existingInstances);
-  const instances = existingInstances[schemaId];
-  const key = instanceId ?? "";
-  if (instances.has(key)) {
-    instances.delete(key);
-  }
-  await DestroySchemaInstance(schemaId, instanceId);
 }

--- a/src/implementations/database/schema.ts
+++ b/src/implementations/database/schema.ts
@@ -31,18 +31,33 @@ function claimOwnership(
   collectionOwnership.set(key, schemaId);
 }
 
-function rollbackRegistration(
-  schemaId: string,
+function releaseOwnership(
   physicalStore: string,
-  claimedTables: string[],
+  tableNames: Iterable<string>,
+  schemaId: string,
 ) {
-  for (const tableName of claimedTables) {
+  for (const tableName of tableNames) {
     const key = ownershipKey(physicalStore, tableName);
     if (collectionOwnership.get(key) === schemaId) {
       collectionOwnership.delete(key);
     }
   }
+}
+
+function rollbackRegistration(
+  schemaId: string,
+  physicalStore: string,
+  claimedTables: string[],
+) {
+  releaseOwnership(physicalStore, claimedTables, schemaId);
   delete existingSchemas[schemaId];
+}
+
+function releasePreviousClaims(schemaId: string) {
+  const previous = existingSchemas[schemaId];
+  if (!previous) return;
+  const previousStore = previous.options.physicalStore ?? schemaId;
+  releaseOwnership(previousStore, Object.keys(previous.definition), schemaId);
 }
 
 export const Schemas = {
@@ -52,6 +67,7 @@ export const Schemas = {
     options: SchemaOptions,
   ) {
     const physicalStore = options.physicalStore ?? schemaId;
+    releasePreviousClaims(schemaId);
     existingSchemas[schemaId] = { definition: schema, options };
     const claimed: string[] = [];
     try {
@@ -69,12 +85,7 @@ export const Schemas = {
     const entry = existingSchemas[schemaId];
     if (entry) {
       const physicalStore = entry.options.physicalStore ?? schemaId;
-      for (const tableName of Object.keys(entry.definition)) {
-        const key = ownershipKey(physicalStore, tableName);
-        if (collectionOwnership.get(key) === schemaId) {
-          collectionOwnership.delete(key);
-        }
-      }
+      releaseOwnership(physicalStore, Object.keys(entry.definition), schemaId);
     }
     delete existingSchemas[schemaId];
   },

--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -229,6 +229,11 @@ export class SelectionQuery extends AggregationPipeline {
   }
 
   private async replace() {
+    if (this.tenant.kind === "cross") {
+      throw new Error(
+        `Replace on tenant-scoped table '${this.tableName}' requires a specific tenant id (CROSS_TENANT would silently strip the tenant_id from the replaced document; use update for cross-tenant mutations)`,
+      );
+    }
     const collection = await GetCollection(this.database, this.collection);
     if (this.tenant.kind === "scoped") {
       this._newValue.tenant_id = this.tenant.tenantId;

--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -6,7 +6,7 @@ import { GetCollection } from "../../connection";
 import { AggregationPipeline } from "./pipeline";
 import { DecodeFunction, DecodeValue } from "./query";
 import { GetPhysicalStore, IsTenantScoped } from "./schema";
-import { DecodingContext } from "./utils";
+import { DecodingContext, TENANT_ID_FIELD } from "./utils";
 
 type TenantContext =
   | { kind: "none" }
@@ -39,7 +39,7 @@ function resolveTenantContext(
 
 function buildInitialPipeline(tenant: TenantContext): any[] {
   if (tenant.kind === "scoped") {
-    return [{ $match: { tenant_id: tenant.tenantId } }];
+    return [{ $match: { [TENANT_ID_FIELD]: tenant.tenantId } }];
   }
   return [];
 }
@@ -144,7 +144,7 @@ export class SelectionQuery extends AggregationPipeline {
     for (const document of documents) {
       document._id = document._id ?? uuidv4();
       if (this.tenant.kind === "scoped") {
-        document.tenant_id = this.tenant.tenantId;
+        document[TENANT_ID_FIELD] = this.tenant.tenantId;
       }
     }
     return documents;
@@ -236,7 +236,7 @@ export class SelectionQuery extends AggregationPipeline {
     }
     const collection = await GetCollection(this.database, this.collection);
     if (this.tenant.kind === "scoped") {
-      this._newValue.tenant_id = this.tenant.tenantId;
+      this._newValue[TENANT_ID_FIELD] = this.tenant.tenantId;
     }
     const res = await collection.findOneAndReplace(
       this.getFilter(),

--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -1,57 +1,76 @@
 import assert from "node:assert";
 import type { QueryStage } from "@antelopejs/interface-database/common";
+import { CROSS_TENANT } from "@antelopejs/interface-database/schema";
 import { v4 as uuidv4 } from "uuid";
-import { buildDatabaseName, GetCollection } from "../../connection";
+import { GetCollection } from "../../connection";
 import { AggregationPipeline } from "./pipeline";
 import { DecodeFunction, DecodeValue } from "./query";
-import {
-  CreateInstance,
-  DestroyInstance,
-  IsRowLevel,
-  IsValidInstance,
-} from "./schema";
+import { GetPhysicalStore, IsTenantScoped } from "./schema";
 import { DecodingContext } from "./utils";
+
+type TenantContext =
+  | { kind: "none" }
+  | { kind: "scoped"; tenantId: string }
+  | { kind: "cross" };
+
+function resolveTenantContext(
+  schemaId: string,
+  tableName: string,
+  instanceId: unknown,
+): TenantContext {
+  if (!IsTenantScoped(schemaId, tableName)) {
+    return { kind: "none" };
+  }
+  if (instanceId === undefined) {
+    throw new Error(
+      `Table '${tableName}' is tenant-scoped: a tenant id must be provided via Schema.instance(...)`,
+    );
+  }
+  if (instanceId === CROSS_TENANT) {
+    return { kind: "cross" };
+  }
+  if (typeof instanceId !== "string") {
+    throw new Error(
+      `Invalid tenant id for table '${tableName}': expected string or CROSS_TENANT, got ${typeof instanceId}`,
+    );
+  }
+  return { kind: "scoped", tenantId: instanceId };
+}
+
+function buildInitialPipeline(tenant: TenantContext): any[] {
+  if (tenant.kind === "scoped") {
+    return [{ $match: { tenant_id: tenant.tenantId } }];
+  }
+  return [];
+}
 
 export class SelectionQuery extends AggregationPipeline {
   private _newValue: any;
   private _conflictMode?: "update" | "replace";
-  private readonly rowLevel: boolean;
-  public readonly instanceId: string | undefined;
+  private readonly tenant: TenantContext;
+  public readonly instanceId: string | typeof CROSS_TENANT | undefined;
   public readonly tableName: string;
 
   public constructor(
     schemaId: string,
-    instanceId: string | undefined,
+    instanceId: string | typeof CROSS_TENANT | undefined,
     tableName: string,
     isChangeStream: boolean,
     context: DecodingContext,
   ) {
-    const rowLevel = IsRowLevel(schemaId);
-    if (rowLevel) {
-      if (instanceId === undefined) {
-        throw new Error(`Row-level schema '${schemaId}' requires a tenant ID`);
-      }
-      super(
-        schemaId,
-        schemaId,
-        tableName,
-        [{ $match: { tenant_id: instanceId } }],
-        isChangeStream,
-        context,
-      );
-    } else {
-      super(
-        schemaId,
-        buildDatabaseName(schemaId, instanceId),
-        tableName,
-        [],
-        isChangeStream,
-        context,
-      );
-    }
+    const tenant = resolveTenantContext(schemaId, tableName, instanceId);
+    const physicalStore = GetPhysicalStore(schemaId);
+    super(
+      schemaId,
+      physicalStore,
+      tableName,
+      buildInitialPipeline(tenant),
+      isChangeStream,
+      context,
+    );
     this.instanceId = instanceId;
     this.tableName = tableName;
-    this.rowLevel = rowLevel;
+    this.tenant = tenant;
     this.resultType = "table";
   }
 
@@ -63,28 +82,6 @@ export class SelectionQuery extends AggregationPipeline {
       const schemaId = stages[0]?.options?.id;
       const instanceId = stages[1]?.options?.id;
       assert(stages[0]?.stage === "schema" && schemaId, "Unknown schema");
-      if (stages[1].stage === "createInstance") {
-        const selection = new SelectionQuery(
-          schemaId,
-          instanceId,
-          "",
-          false,
-          new DecodingContext(),
-        );
-        selection.resultType = "createInstance";
-        return selection;
-      }
-      if (stages[1].stage === "destroyInstance") {
-        const selection = new SelectionQuery(
-          schemaId,
-          instanceId,
-          "",
-          false,
-          new DecodingContext(),
-        );
-        selection.resultType = "destroyInstance";
-        return selection;
-      }
       assert(
         stages[1].stage === "instance" && stages[2]?.stage === "table",
         "Invalid request",
@@ -125,22 +122,12 @@ export class SelectionQuery extends AggregationPipeline {
     }
   }
 
-  private async createInstance() {
-    if (this.rowLevel) {
-      return this.instanceId;
-    }
-    await CreateInstance(this.schemaId, this.instanceId);
-    return this.instanceId;
-  }
-
-  private async destroyInstance() {
-    if (this.rowLevel) {
-      return;
-    }
-    await DestroyInstance(this.schemaId, this.instanceId);
-  }
-
   private async insert() {
+    if (this.tenant.kind === "cross") {
+      throw new Error(
+        `Insert into tenant-scoped table '${this.tableName}' requires a specific tenant id (CROSS_TENANT is read-only)`,
+      );
+    }
     const collection = await GetCollection(this.database, this.collection);
     const documents = this.prepareInsertDocuments();
     if (!this._conflictMode) {
@@ -156,8 +143,8 @@ export class SelectionQuery extends AggregationPipeline {
       : [this._newValue];
     for (const document of documents) {
       document._id = document._id ?? uuidv4();
-      if (this.rowLevel) {
-        document.tenant_id = this.instanceId;
+      if (this.tenant.kind === "scoped") {
+        document.tenant_id = this.tenant.tenantId;
       }
     }
     return documents;
@@ -243,8 +230,8 @@ export class SelectionQuery extends AggregationPipeline {
 
   private async replace() {
     const collection = await GetCollection(this.database, this.collection);
-    if (this.rowLevel) {
-      this._newValue.tenant_id = this.instanceId;
+    if (this.tenant.kind === "scoped") {
+      this._newValue.tenant_id = this.tenant.tenantId;
     }
     const res = await collection.findOneAndReplace(
       this.getFilter(),
@@ -259,26 +246,8 @@ export class SelectionQuery extends AggregationPipeline {
     return res.deletedCount;
   }
 
-  private async ensureInstance() {
-    if (!IsValidInstance(this.schemaId, this.instanceId)) {
-      throw new Error(
-        `Instance '${this.instanceId ?? "(global)"}' does not exist for schema '${this.schemaId}'`,
-      );
-    }
-  }
-
   public async run(): Promise<any> {
-    if (
-      this.resultType !== "createInstance" &&
-      this.resultType !== "destroyInstance"
-    ) {
-      await this.ensureInstance();
-    }
     switch (this.resultType) {
-      case "createInstance":
-        return this.createInstance();
-      case "destroyInstance":
-        return this.destroyInstance();
       case "insert":
         return this.insert();
       case "update":

--- a/src/implementations/database/utils.ts
+++ b/src/implementations/database/utils.ts
@@ -2,6 +2,8 @@ import assert from "node:assert";
 import type { StagedObject } from "@antelopejs/interface-database/common";
 import { generate as randomstring } from "randomstring";
 
+export const TENANT_ID_FIELD = "tenant_id";
+
 export function Temporary(name?: string) {
   return `temporary_${name ? `${name}_` : ""}${randomstring({ capitalization: "lowercase", length: 16 })}`;
 }


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adapts the MongoDB implementation to the new `@antelopejs/interface-database@^0.1.0` API. The interface drops the per-instance database model in favor of a shared **physical store** with per-table **tenant scoping**.

**Schema layer (`schema.ts`)**
- `register()` now initializes the schema directly inside the resolved physical store (`options.physicalStore ?? schemaId`).
- Collection ownership is tracked across schemas sharing a physical store: a table declared by one schema can no longer be redeclared by another.
- `IsRowLevel` is replaced by `IsTenantScoped(schemaId, tableId)` — tenant scoping is now per-table, not per-schema.
- `CreateInstance` / `DestroyInstance` / `IsValidInstance` are removed; instances are no longer materialized.

**Connection layer (`connection.ts`)**
- `CreateRowLevelDatabase`, `CreateSchemaInstance`, `DestroySchemaInstance`, and `buildDatabaseName` are replaced by a single `InitializeSchemaInPhysicalStore(physicalStore, schema)`.
- Initialization is split into focused helpers: `ensureCollection`, `syncSecondaryIndexes`, `ensureTenantIndex`.

**Selection layer (`selection.ts`)**
- New `TenantContext` (`none` | `scoped` | `cross`) drives query construction. The initial `$match { tenant_id }` is added only when the table is tenant-scoped and a tenant id was provided.
- Adds support for the new `CROSS_TENANT` symbol — read-only access across tenants. Inserts under `CROSS_TENANT` are rejected.
- Drops `createInstance` / `destroyInstance` query stages.

**Pipeline layer (`pipeline.ts`)**
- Removes the cross-database `$lookup` post-processing workaround. With all related tables now living in the same physical store, MongoDB's native `$lookup` is sufficient.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the MongoDB adapter from `@antelopejs/interface-database@^0.0.3` to `^0.1.0`, replacing the per-instance database model with a shared physical store and per-table tenant scoping via a `TenantContext` discriminated union.

- **Schema layer** (`schema.ts`): removes `existingInstances` in favour of a `collectionOwnership` map; adds `releasePreviousClaims` + try/catch rollback to handle partial registration failures and hot-reload re-registration.
- **Selection layer** (`selection.ts`): introduces `resolveTenantContext` to produce typed `TenantContext`; `insert()` and `replace()` guard against `CROSS_TENANT` writes; `update()` and `delete()` are missing the same guard, leaving them capable of mutating across all tenants when `CROSS_TENANT` is in effect.
- **Pipeline layer** (`pipeline.ts`): removes the cross-database post-processing workaround and replaces it with `assertSamePhysicalStore()`, which correctly throws at decode time when a subquery targets a different physical store.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until update() and delete() receive the same CROSS_TENANT write guard that insert() and replace() already have.

update() and delete() in selection.ts operate on getFilter(), which returns an empty filter when the tenant context is "cross" (buildInitialPipeline returns [] for CROSS_TENANT). An updateMany or deleteMany issued under CROSS_TENANT would therefore silently modify or remove records across every tenant in the collection rather than being rejected. insert() and replace() correctly throw in this case, but the same protection is absent from the two mutation paths that produce the broadest blast radius.

src/implementations/database/selection.ts — update() and delete() methods need CROSS_TENANT guards before this change can be safely deployed

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/implementations/database/selection.ts | Introduces TenantContext discriminated union and per-table tenant scoping; insert() and replace() guard against CROSS_TENANT writes, but update() and delete() lack the same guard — flagged in a prior outside-diff comment that remains unaddressed. |
| src/implementations/database/schema.ts | Replaces instance tracking with collection-ownership map; adds rollback on partial registration failures via rollbackRegistration(). Prior thread comments on mid-registration corruption and ghost-ownership on re-register are addressed by releasePreviousClaims + rollback pattern. |
| src/implementations/database/pipeline.ts | Removes cross-database post-processing workaround and replaces it with assertSamePhysicalStore(), which throws at decode-time for cross-store subqueries. Guard is correctly applied in addStages(), stage_union(), stage_join(), and stage_lookup(). |
| src/connection.ts | Refactors into focused helpers (ensureCollection, syncSecondaryIndexes, ensureTenantIndex) and a single InitializeSchemaInPhysicalStore entry point. Logic is clean; TENANT_ID_INDEX is a local string constant that duplicates the exported TENANT_ID_FIELD from utils.ts. |
| src/implementations/database/utils.ts | Adds the exported TENANT_ID_FIELD constant ("tenant_id") to centralise the field name; minimal change. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/implementations/database/selection.ts`, line 219-247 ([link](https://github.com/antelopejs/mongodb/blob/267a70cb73b6d58df782bcb8bb0bac75f615670a/src/implementations/database/selection.ts#L219-L247)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing CROSS_TENANT write guard in `update()`, `replace()`, and `delete()`**

   `insert()` correctly rejects writes when `this.tenant.kind === "cross"`, but `update()`, `replace()`, and `delete()` have no equivalent guard. For a `CROSS_TENANT` context, `buildInitialPipeline` returns an empty array (no `tenant_id` `$match` stage), so the filter produced by `getFilter()` has no tenant scope. An `updateMany` or `deleteMany` issued under `CROSS_TENANT` would therefore operate across **all tenants** rather than being blocked. Additionally, `replace()` skips setting `tenant_id` on the replacement document, so the `tenant_id` field is silently stripped from any replaced record.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/implementations/database/selection.ts
   Line: 219-247

   Comment:
   **Missing CROSS_TENANT write guard in `update()`, `replace()`, and `delete()`**

   `insert()` correctly rejects writes when `this.tenant.kind === "cross"`, but `update()`, `replace()`, and `delete()` have no equivalent guard. For a `CROSS_TENANT` context, `buildInitialPipeline` returns an empty array (no `tenant_id` `$match` stage), so the filter produced by `getFilter()` has no tenant scope. An `updateMany` or `deleteMany` issued under `CROSS_TENANT` would therefore operate across **all tenants** rather than being blocked. Additionally, `replace()` skips setting `tenant_id` on the replacement document, so the `tenant_id` field is silently stripped from any replaced record.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/implementations/database/pipeline.ts`, line 152-166 ([link](https://github.com/antelopejs/mongodb/blob/267a70cb73b6d58df782bcb8bb0bac75f615670a/src/implementations/database/pipeline.ts#L152-L166)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Cross-physical-store `$lookup` / `$unionWith` is now silently wrong instead of handled**

   The old `isCrossDatabase` guard detected when the right-hand stream lived in a different MongoDB database and routed it through a post-processing path. That guard and path are removed. MongoDB's native `$lookup` (and `$unionWith`) only work within a single database; if the left and right streams resolve to different physical stores, the lookup silently queries the *current* database for a collection that doesn't exist there and returns empty results rather than an error. There is currently no check that `this.database === rightStream.database` before emitting a `$lookup`, so any cross-physical-store subquery will now silently produce wrong data.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/implementations/database/pipeline.ts
   Line: 152-166

   Comment:
   **Cross-physical-store `$lookup` / `$unionWith` is now silently wrong instead of handled**

   The old `isCrossDatabase` guard detected when the right-hand stream lived in a different MongoDB database and routed it through a post-processing path. That guard and path are removed. MongoDB's native `$lookup` (and `$unionWith`) only work within a single database; if the left and right streams resolve to different physical stores, the lookup silently queries the *current* database for a collection that doesn't exist there and returns empty results rather than an error. There is currently no check that `this.database === rightStream.database` before emitting a `$lookup`, so any cross-physical-store subquery will now silently produce wrong data.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `src/implementations/database/selection.ts`, line 219-252 ([link](https://github.com/antelopejs/mongodb/blob/284cb7f0bc7c76cb0a6fcf7912120d8eb4b3929d/src/implementations/database/selection.ts#L219-L252)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing CROSS_TENANT write guard in `update()` and `delete()`**

   `insert()` and `replace()` both throw when `this.tenant.kind === "cross"`, but `update()` and `delete()` do not. For a `CROSS_TENANT` context, `buildInitialPipeline` returns `[]`, so `getFilter()` produces no `tenant_id` constraint. An `updateMany` or `deleteMany` issued under `CROSS_TENANT` will therefore silently operate across **all tenants** rather than being rejected. Both methods need the same guard that `replace()` already has.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/implementations/database/selection.ts
   Line: 219-252

   Comment:
   **Missing CROSS_TENANT write guard in `update()` and `delete()`**

   `insert()` and `replace()` both throw when `this.tenant.kind === "cross"`, but `update()` and `delete()` do not. For a `CROSS_TENANT` context, `buildInitialPipeline` returns `[]`, so `getFilter()` produces no `tenant_id` constraint. An `updateMany` or `deleteMany` issued under `CROSS_TENANT` will therefore silently operate across **all tenants** rather than being rejected. Both methods need the same guard that `replace()` already has.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/connection.ts:8-10
`TENANT_ID_INDEX` is a module-local constant with the same value (`"tenant_id"`) as the already-exported `TENANT_ID_FIELD` from `utils.ts`, which is already imported on the line above. Using `TENANT_ID_FIELD` for both the index name and the field key removes the redundant constant and keeps the value in one place.

```suggestion
import { TENANT_ID_FIELD } from "./implementations/database/utils";

const TENANT_ID_INDEX = TENANT_ID_FIELD;
```


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: release stale ownership claims when..."](https://github.com/antelopejs/mongodb/commit/180f563cc375ac24bd983db500d83ad8f8c2be4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31492582)</sub>

<!-- /greptile_comment -->