### PR TITLE
feat(database): single physical DB with prefixed collections, explicit instance lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.2.0
+
+### ⚠ Breaking Changes (pre-adoption — minor bump)
+
+- **database:** Single physical MongoDB database for all schemas — configured via the new required `database` option in module config. Collections are now named `<schemaId>__<tableName>`. Cross-schema `$lookup` and `$unionWith` are now native (no more `Cross-physical-store subquery not supported` error).
+- **database:** Removed `SchemaOptions.physicalStore` and `TableDefinition.tenantScoped` (interface-side revert). Removed `assertSamePhysicalStore` guard.
+- **database:** Per-document instance marker renamed from `tenant_id` to `_instance`. Default (unnamed) instance stores `_instance: null`; named instances store the string id.
+- **database:** `CROSS_TENANT` symbol renamed to `CROSS_INSTANCE` (interface-side); `TenantId` → `InstanceId`.
+- **database:** Re-introduced explicit instance lifecycle. `createInstance` / `destroyInstance` / `listInstances` are now backed by an adapter-owned `__antelope_instances` collection.
+
+### Migration
+
+Existing on-disk data is not readable post-upgrade: the database name, collection names, and per-document instance field have all changed. Operators must run a one-off migration with `mongodump` / `mongorestore` (or a shell script) to:
+
+1. Move collections from `<schemaId>` DBs into the new single configured database.
+2. Rename collections from `<tableName>` to `<schemaId>__<tableName>`.
+3. Rename the `tenant_id` field on every document to `_instance` (or, if no tenant existed, stamp `_instance: null`).
+4. Optionally seed `__antelope_instances` from the distinct `_instance` values per schema.
+
 ## v1.1.0
 
 [compare changes](https://github.com/AntelopeJS/mongodb/compare/v1.0.8...v1.1.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antelopejs/mongodb",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "MongoDB module that implements the Database interface of antelopejs",
   "keywords": [
     "antelopejs",
@@ -37,7 +37,8 @@
       "@antelopejs/interface-mongodb"
     ],
     "defaultConfig": {
-      "url": "mongodb://localhost:27017"
+      "url": "mongodb://localhost:27017",
+      "database": "antelopejs"
     },
     "test": "src/test/antelope.test.ts"
   },

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -5,15 +5,27 @@ import {
   MongoClient,
   type MongoClientOptions,
 } from "mongodb";
-import { TENANT_ID_FIELD } from "./implementations/database/utils";
+import {
+  BOOKKEEPING_COLLECTION,
+  INSTANCE_FIELD,
+  collectionName,
+} from "./implementations/database/utils";
 
-const TENANT_ID_INDEX = "tenant_id";
+const INSTANCE_INDEX = "_instance";
+const BOOKKEEPING_INDEX = "schemaId_instanceId";
 
-export async function Connect(url: string, options?: MongoClientOptions) {
+let configuredDatabase: string | undefined;
+
+export async function Connect(
+  url: string,
+  database: string,
+  options?: MongoClientOptions,
+) {
   await Disconnect();
   const mongoClient = await MongoClient.connect(url, options);
   internal.connected = true;
   internal.SetClient(mongoClient);
+  configuredDatabase = database;
 }
 
 export async function Disconnect() {
@@ -22,19 +34,28 @@ export async function Disconnect() {
     internal.connected = false;
     internal.UnsetClient();
   }
+  configuredDatabase = undefined;
 }
 
-export async function GetCollection(
-  database: string,
-  collection: string,
-): Promise<Collection> {
+export function GetConfiguredDatabaseName(): string {
+  if (!configuredDatabase) {
+    throw new Error(
+      "MongoDB adapter is not connected: call construct({ url, database }) first",
+    );
+  }
+  return configuredDatabase;
+}
+
+export async function GetCollection(collection: string): Promise<Collection> {
+  const dbName = GetConfiguredDatabaseName();
   return internal.client.then((client) =>
-    client.db(database).collection(collection),
+    client.db(dbName).collection(collection),
   );
 }
 
-export async function GetDatabase(database: string): Promise<Db> {
-  return internal.client.then((client) => client.db(database));
+export async function GetDatabase(): Promise<Db> {
+  const dbName = GetConfiguredDatabaseName();
+  return internal.client.then((client) => client.db(dbName));
 }
 
 export async function ListDatabases(): Promise<{ name: string }[]> {
@@ -51,7 +72,6 @@ export interface IndexDefinition {
 
 export interface TableDefinition {
   indexes: Record<string, IndexDefinition>;
-  tenantScoped?: boolean;
 }
 
 export interface SchemaDefinition {
@@ -60,12 +80,19 @@ export interface SchemaDefinition {
 
 async function ensureCollection(
   db: Db,
-  tableId: string,
+  collectionId: string,
   existingCollections: Set<string>,
 ) {
-  if (!existingCollections.has(tableId)) {
-    await db.createCollection(tableId);
+  if (!existingCollections.has(collectionId)) {
+    await db.createCollection(collectionId, {
+      changeStreamPreAndPostImages: { enabled: true },
+    });
+    return;
   }
+  await db.command({
+    collMod: collectionId,
+    changeStreamPreAndPostImages: { enabled: true },
+  });
 }
 
 async function syncSecondaryIndexes(
@@ -101,32 +128,50 @@ async function syncSecondaryIndexes(
   }
 }
 
-async function ensureTenantIndex(collection: Collection) {
+async function ensureInstanceIndex(collection: Collection) {
   const existingIndexes = await collection.indexes();
-  const hasTenantIndex = existingIndexes.some(
+  const hasInstanceIndex = existingIndexes.some(
     (index) =>
-      index.name === TENANT_ID_INDEX ||
-      (Object.keys(index.key).length === 1 && index.key[TENANT_ID_FIELD]),
+      index.name === INSTANCE_INDEX ||
+      (Object.keys(index.key).length === 1 && index.key[INSTANCE_FIELD]),
   );
-  if (!hasTenantIndex) {
-    await collection.createIndex([TENANT_ID_FIELD], { name: TENANT_ID_INDEX });
+  if (!hasInstanceIndex) {
+    await collection.createIndex([INSTANCE_FIELD], { name: INSTANCE_INDEX });
   }
 }
 
-export async function InitializeSchemaInPhysicalStore(
-  physicalStore: string,
+export async function InitializeSchema(
+  schemaId: string,
   schema: SchemaDefinition,
 ) {
-  const db = await GetDatabase(physicalStore);
+  const db = await GetDatabase();
   const existingCollections = new Set(
     (await db.listCollections().toArray()).map((collection) => collection.name),
   );
   for (const [tableId, table] of Object.entries(schema)) {
-    await ensureCollection(db, tableId, existingCollections);
-    const collection = db.collection(tableId);
+    const mongoCollection = collectionName(schemaId, tableId);
+    await ensureCollection(db, mongoCollection, existingCollections);
+    const collection = db.collection(mongoCollection);
     await syncSecondaryIndexes(collection, table);
-    if (table.tenantScoped) {
-      await ensureTenantIndex(collection);
-    }
+    await ensureInstanceIndex(collection);
+  }
+}
+
+export async function EnsureBookkeepingCollection() {
+  const db = await GetDatabase();
+  const existing = new Set(
+    (await db.listCollections().toArray()).map((c) => c.name),
+  );
+  if (!existing.has(BOOKKEEPING_COLLECTION)) {
+    await db.createCollection(BOOKKEEPING_COLLECTION);
+  }
+  const collection = db.collection(BOOKKEEPING_COLLECTION);
+  const indexes = await collection.indexes();
+  const hasIndex = indexes.some((idx) => idx.name === BOOKKEEPING_INDEX);
+  if (!hasIndex) {
+    await collection.createIndex(
+      { schemaId: 1, instanceId: 1 },
+      { name: BOOKKEEPING_INDEX, unique: true },
+    );
   }
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -83,14 +83,10 @@ async function ensureCollection(
   collectionId: string,
   existingCollections: Set<string>,
 ) {
-  if (!existingCollections.has(collectionId)) {
-    await db.createCollection(collectionId, {
-      changeStreamPreAndPostImages: { enabled: true },
-    });
+  if (existingCollections.has(collectionId)) {
     return;
   }
-  await db.command({
-    collMod: collectionId,
+  await db.createCollection(collectionId, {
     changeStreamPreAndPostImages: { enabled: true },
   });
 }

--- a/src/implementations/database/instances.ts
+++ b/src/implementations/database/instances.ts
@@ -1,0 +1,66 @@
+import { CROSS_INSTANCE } from "@antelopejs/interface-database/schema";
+import { GetCollection } from "../../connection";
+import { GetTableNames } from "./schema";
+import {
+  BOOKKEEPING_COLLECTION,
+  INSTANCE_FIELD,
+  collectionName,
+} from "./utils";
+
+function rejectCrossInstance(action: string, value: unknown) {
+  if (value === CROSS_INSTANCE) {
+    throw new Error(
+      `${action} does not accept CROSS_INSTANCE: pass a string id or omit for the default instance`,
+    );
+  }
+}
+
+function normalizeId(id: unknown): string | null {
+  if (id === undefined || id === null) {
+    return null;
+  }
+  if (typeof id !== "string") {
+    throw new Error(
+      `Invalid instance id: expected string or undefined, got ${typeof id}`,
+    );
+  }
+  return id;
+}
+
+export async function CreateInstance(
+  schemaId: string,
+  id: unknown,
+): Promise<string> {
+  rejectCrossInstance("createInstance", id);
+  const instanceId = normalizeId(id);
+  const collection = await GetCollection(BOOKKEEPING_COLLECTION);
+  await collection.updateOne(
+    { schemaId, instanceId },
+    { $setOnInsert: { schemaId, instanceId, createdAt: new Date() } },
+    { upsert: true },
+  );
+  return instanceId ?? "";
+}
+
+export async function DestroyInstance(
+  schemaId: string,
+  id: unknown,
+): Promise<void> {
+  rejectCrossInstance("destroyInstance", id);
+  const instanceId = normalizeId(id);
+  for (const tableName of GetTableNames(schemaId)) {
+    const collection = await GetCollection(collectionName(schemaId, tableName));
+    await collection.deleteMany({ [INSTANCE_FIELD]: instanceId });
+  }
+  const bookkeeping = await GetCollection(BOOKKEEPING_COLLECTION);
+  await bookkeeping.deleteOne({ schemaId, instanceId });
+}
+
+export async function ListInstances(schemaId: string): Promise<string[]> {
+  const collection = await GetCollection(BOOKKEEPING_COLLECTION);
+  const rows = await collection
+    .find({ schemaId, instanceId: { $ne: null } })
+    .project({ instanceId: 1 })
+    .toArray();
+  return rows.map((row) => row.instanceId as string);
+}

--- a/src/implementations/database/instances.ts
+++ b/src/implementations/database/instances.ts
@@ -5,6 +5,7 @@ import {
   BOOKKEEPING_COLLECTION,
   INSTANCE_FIELD,
   collectionName,
+  normalizeInstanceId,
 } from "./utils";
 
 function rejectCrossInstance(action: string, value: unknown) {
@@ -15,24 +16,12 @@ function rejectCrossInstance(action: string, value: unknown) {
   }
 }
 
-function normalizeId(id: unknown): string | null {
-  if (id === undefined || id === null) {
-    return null;
-  }
-  if (typeof id !== "string") {
-    throw new Error(
-      `Invalid instance id: expected string or undefined, got ${typeof id}`,
-    );
-  }
-  return id;
-}
-
 export async function CreateInstance(
   schemaId: string,
   id: unknown,
 ): Promise<string> {
   rejectCrossInstance("createInstance", id);
-  const instanceId = normalizeId(id);
+  const instanceId = normalizeInstanceId(id);
   const collection = await GetCollection(BOOKKEEPING_COLLECTION);
   await collection.updateOne(
     { schemaId, instanceId },
@@ -47,7 +36,7 @@ export async function DestroyInstance(
   id: unknown,
 ): Promise<void> {
   rejectCrossInstance("destroyInstance", id);
-  const instanceId = normalizeId(id);
+  const instanceId = normalizeInstanceId(id);
   for (const tableName of GetTableNames(schemaId)) {
     const collection = await GetCollection(collectionName(schemaId, tableName));
     await collection.deleteMany({ [INSTANCE_FIELD]: instanceId });

--- a/src/implementations/database/pipeline.ts
+++ b/src/implementations/database/pipeline.ts
@@ -39,16 +39,21 @@ export class AggregationPipeline {
    */
   public inCompoundObject = false;
 
+  public readonly initialFilter: any[];
+  public readonly pipeline: any[];
+
   public constructor(
     public readonly schemaId: string,
     public readonly tableName: string,
     public readonly collection: string,
-    public readonly pipeline: any[],
+    initialFilter: any[],
     public readonly isChangeStream: boolean,
     public readonly context: DecodingContext,
   ) {
+    this.initialFilter = initialFilter;
+    this.pipeline = [...initialFilter];
     if (isChangeStream) {
-      pipeline.unshift(
+      this.pipeline.unshift(
         {
           $changeStream: {
             fullDocument: "updateLookup",
@@ -131,7 +136,7 @@ export class AggregationPipeline {
             from: rightStream.collection,
             let: { [arrVar]: arraySource },
             pipeline: [
-              ...rightStream.pipeline.slice(0, 1),
+              ...rightStream.initialFilter,
               { $match: { $expr: { $in: [`$${matchField}`, `$$${arrVar}`] } } },
             ],
             as: tmp,

--- a/src/implementations/database/pipeline.ts
+++ b/src/implementations/database/pipeline.ts
@@ -131,6 +131,7 @@ export class AggregationPipeline {
             from: rightStream.collection,
             let: { [arrVar]: arraySource },
             pipeline: [
+              ...rightStream.pipeline.slice(0, 1),
               { $match: { $expr: { $in: [`$${matchField}`, `$$${arrVar}`] } } },
             ],
             as: tmp,

--- a/src/implementations/database/pipeline.ts
+++ b/src/implementations/database/pipeline.ts
@@ -41,7 +41,7 @@ export class AggregationPipeline {
 
   public constructor(
     public readonly schemaId: string,
-    public readonly database: string,
+    public readonly tableName: string,
     public readonly collection: string,
     public readonly pipeline: any[],
     public readonly isChangeStream: boolean,
@@ -73,10 +73,11 @@ export class AggregationPipeline {
   ): Promise<AggregationPipeline> {
     if (stages[0]?.stage === "arg") {
       assert(context, "Arg query without context?");
+      const argRef = stages[0].args[0];
       const query = new AggregationPipeline(
         "",
-        "$ARG",
-        stages[0].args[0],
+        argRef,
+        argRef,
         [],
         false,
         context,
@@ -92,18 +93,6 @@ export class AggregationPipeline {
 
   private pendingUnset: string[] = [];
 
-  private assertSamePhysicalStore(rightStream: AggregationPipeline) {
-    if (
-      this.database !== "$ARG" &&
-      rightStream.database !== "$ARG" &&
-      rightStream.database !== this.database
-    ) {
-      throw new Error(
-        `Cross-physical-store subquery not supported: '${this.database}' → '${rightStream.database}'. Co-locate the schemas via SchemaOptions.physicalStore or perform the lookup in application code.`,
-      );
-    }
-  }
-
   public async addStages(stages: QueryStage[]) {
     const oldSubquery = this.context.subquery;
     this.context.subquery = async (subQuery) => {
@@ -114,7 +103,6 @@ export class AggregationPipeline {
         subQuery,
         this.context.withRoot(`$$${tmpRoot}`),
       );
-      this.assertSamePhysicalStore(rightStream);
 
       // Check if the FK value is a $map variable ($$temporary_*).
       // $lookup pipeline can't access $map variables — they only exist
@@ -196,7 +184,7 @@ export class AggregationPipeline {
   }
 
   public async run(): Promise<any> {
-    const collection = await GetCollection(this.database, this.collection);
+    const collection = await GetCollection(this.collection);
     let result = await collection.aggregate(this.pipeline, {}).toArray();
     if (this.wrappedObject) {
       const wrappedObject = this.wrappedObject;
@@ -209,7 +197,7 @@ export class AggregationPipeline {
   }
 
   public async runDebug(limit = 10): Promise<any[]> {
-    const collection = await GetCollection(this.database, this.collection);
+    const collection = await GetCollection(this.collection);
     const results = [];
     try {
       for (let i = 0; i <= this.pipeline.length; ++i) {
@@ -225,7 +213,7 @@ export class AggregationPipeline {
 
   public async readCursor() {
     if (!this.cursor) {
-      const collection = await GetCollection(this.database, this.collection);
+      const collection = await GetCollection(this.collection);
       this.cursor = collection.aggregate(this.pipeline, {});
     }
     const change = await this.cursor.next();
@@ -437,7 +425,6 @@ export class AggregationPipeline {
       this.context,
     );
     assert(rightStream instanceof AggregationPipeline);
-    this.assertSamePhysicalStore(rightStream);
 
     if (this.wrappedObject !== rightStream.wrappedObject) {
       if (!this.wrappedObject) {
@@ -468,7 +455,6 @@ export class AggregationPipeline {
     const predicate = stage.args[1];
     const mapper = stage.args[2];
     assert(rightStream instanceof AggregationPipeline);
-    this.assertSamePhysicalStore(rightStream);
     const root = this.getRoot();
     const tmp = Temporary("join");
     this.pipeline.push(
@@ -511,7 +497,6 @@ export class AggregationPipeline {
       this.context,
     );
     assert(rightStream instanceof SelectionQuery);
-    this.assertSamePhysicalStore(rightStream);
 
     const localField = this.getField(stage.options.localKey);
     const foreignField = stage.options.otherKey;
@@ -547,7 +532,7 @@ export class AggregationPipeline {
   protected async stage_group(stage: QueryStage) {
     const root = this.getRoot();
     const group = Temporary("group");
-    const index = GetIndex(this.schemaId, this.collection, stage.options.index);
+    const index = GetIndex(this.schemaId, this.tableName, stage.options.index);
     const indexFields = index.fields ?? [stage.options.index];
 
     let groupKey: unknown;
@@ -625,7 +610,7 @@ export class AggregationPipeline {
 
   protected stage_orderBy(stage: QueryStage) {
     assert(!this.isChangeStream, "OrderBy not supported in change streams");
-    const index = GetIndex(this.schemaId, this.collection, stage.options.index);
+    const index = GetIndex(this.schemaId, this.tableName, stage.options.index);
     const direction = stage.options.direction === "desc" ? -1 : 1;
     const indexFields = index.fields ?? [stage.options.index];
     const fields = indexFields.map((field) => [

--- a/src/implementations/database/query.ts
+++ b/src/implementations/database/query.ts
@@ -2,9 +2,38 @@ import assert from "node:assert";
 import { Query, ValueProxy } from "@antelopejs/interface-database";
 import type { Value } from "@antelopejs/interface-database/common";
 import { Expression } from "./expression";
+import {
+  CreateInstance,
+  DestroyInstance,
+  ListInstances,
+} from "./instances";
 import type { AggregationPipeline } from "./pipeline";
 import { SelectionQuery } from "./selection";
 import type { ArgumentProvider, DecodingContext, QueryStage } from "./utils";
+
+const LIFECYCLE_HANDLERS: Record<
+  string,
+  (schemaId: string, stage: QueryStage) => Promise<unknown>
+> = {
+  createInstance: (schemaId, stage) =>
+    CreateInstance(schemaId, stage.options?.id),
+  destroyInstance: (schemaId, stage) =>
+    DestroyInstance(schemaId, stage.options?.id),
+  listInstances: (schemaId) => ListInstances(schemaId),
+};
+
+function tryHandleLifecycle(stages: QueryStage[]): Promise<unknown> | undefined {
+  if (stages.length !== 2 || stages[0]?.stage !== "schema") {
+    return undefined;
+  }
+  const handler = LIFECYCLE_HANDLERS[stages[1].stage];
+  if (!handler) {
+    return undefined;
+  }
+  const schemaId = stages[0].options?.id;
+  assert(typeof schemaId === "string", "Lifecycle query missing schema id");
+  return handler(schemaId, stages[1]);
+}
 
 export async function DecodeValue(
   value: Value<unknown>,
@@ -60,6 +89,10 @@ export async function DecodeFunction(
 }
 
 export async function RunQuery(stages: QueryStage[]) {
+  const lifecycle = tryHandleLifecycle(stages);
+  if (lifecycle) {
+    return await lifecycle;
+  }
   const query = await SelectionQuery.decode(stages);
   return await query.run();
 }

--- a/src/implementations/database/schema.ts
+++ b/src/implementations/database/schema.ts
@@ -1,104 +1,22 @@
 import assert from "node:assert";
-import type {
-  SchemaDefinition,
-  SchemaOptions,
-} from "@antelopejs/interface-database/schema";
-import { InitializeSchemaInPhysicalStore } from "../../connection";
+import type { SchemaDefinition } from "@antelopejs/interface-database/schema";
+import { InitializeSchema } from "../../connection";
 
-const existingSchemas: Record<
-  string,
-  { definition: SchemaDefinition; options: SchemaOptions }
-> = {};
-
-const collectionOwnership = new Map<string, string>();
-
-function ownershipKey(physicalStore: string, tableName: string): string {
-  return `${physicalStore}\0${tableName}`;
-}
-
-function claimOwnership(
-  physicalStore: string,
-  tableName: string,
-  schemaId: string,
-) {
-  const key = ownershipKey(physicalStore, tableName);
-  const owner = collectionOwnership.get(key);
-  if (owner && owner !== schemaId) {
-    throw new Error(
-      `Collection '${tableName}' in physical store '${physicalStore}' is already declared by schema '${owner}', cannot redeclare in '${schemaId}'`,
-    );
-  }
-  collectionOwnership.set(key, schemaId);
-}
-
-function releaseOwnership(
-  physicalStore: string,
-  tableNames: Iterable<string>,
-  schemaId: string,
-) {
-  for (const tableName of tableNames) {
-    const key = ownershipKey(physicalStore, tableName);
-    if (collectionOwnership.get(key) === schemaId) {
-      collectionOwnership.delete(key);
-    }
-  }
-}
-
-function rollbackRegistration(
-  schemaId: string,
-  physicalStore: string,
-  claimedTables: string[],
-) {
-  releaseOwnership(physicalStore, claimedTables, schemaId);
-  delete existingSchemas[schemaId];
-}
-
-function releasePreviousClaims(schemaId: string) {
-  const previous = existingSchemas[schemaId];
-  if (!previous) return;
-  const previousStore = previous.options.physicalStore ?? schemaId;
-  releaseOwnership(previousStore, Object.keys(previous.definition), schemaId);
-}
+const existingSchemas: Record<string, SchemaDefinition> = {};
 
 export const Schemas = {
-  async register(
-    schemaId: string,
-    schema: SchemaDefinition,
-    options: SchemaOptions,
-  ) {
-    const physicalStore = options.physicalStore ?? schemaId;
-    releasePreviousClaims(schemaId);
-    existingSchemas[schemaId] = { definition: schema, options };
-    const claimed: string[] = [];
-    try {
-      for (const tableName of Object.keys(schema)) {
-        claimOwnership(physicalStore, tableName, schemaId);
-        claimed.push(tableName);
-      }
-      await InitializeSchemaInPhysicalStore(physicalStore, schema);
-    } catch (err) {
-      rollbackRegistration(schemaId, physicalStore, claimed);
-      throw err;
-    }
+  async register(schemaId: string, schema: SchemaDefinition) {
+    existingSchemas[schemaId] = schema;
+    await InitializeSchema(schemaId, schema);
   },
   unregister(schemaId: string) {
-    const entry = existingSchemas[schemaId];
-    if (entry) {
-      const physicalStore = entry.options.physicalStore ?? schemaId;
-      releaseOwnership(physicalStore, Object.keys(entry.definition), schemaId);
-    }
     delete existingSchemas[schemaId];
   },
 };
 
-export function GetPhysicalStore(schemaId: string): string {
-  assert(schemaId in existingSchemas, `Unknown schema '${schemaId}'`);
-  return existingSchemas[schemaId].options.physicalStore ?? schemaId;
-}
-
 export function GetSchema(schemaId: string) {
   assert(schemaId in existingSchemas);
-  return existingSchemas[schemaId].definition;
+  return existingSchemas[schemaId];
 }
 
 export function GetTable(schemaId: string, tableId: string) {
@@ -107,8 +25,8 @@ export function GetTable(schemaId: string, tableId: string) {
   return schema[tableId];
 }
 
-export function IsTenantScoped(schemaId: string, tableId: string): boolean {
-  return GetTable(schemaId, tableId).tenantScoped === true;
+export function GetTableNames(schemaId: string): string[] {
+  return Object.keys(GetSchema(schemaId));
 }
 
 export function GetIndex(

--- a/src/implementations/database/schema.ts
+++ b/src/implementations/database/schema.ts
@@ -7,7 +7,12 @@ const existingSchemas: Record<string, SchemaDefinition> = {};
 export const Schemas = {
   async register(schemaId: string, schema: SchemaDefinition) {
     existingSchemas[schemaId] = schema;
-    await InitializeSchema(schemaId, schema);
+    try {
+      await InitializeSchema(schemaId, schema);
+    } catch (err) {
+      delete existingSchemas[schemaId];
+      throw err;
+    }
   },
   unregister(schemaId: string) {
     delete existingSchemas[schemaId];

--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -34,13 +34,17 @@ function buildInitialPipeline(
     return [
       {
         $match: {
-          $or: [
-            { [`fullDocument.${INSTANCE_FIELD}`]: instance.instanceId },
-            {
-              [`fullDocumentBeforeChange.${INSTANCE_FIELD}`]:
-                instance.instanceId,
-            },
-          ],
+          $expr: {
+            $eq: [
+              {
+                $ifNull: [
+                  `$fullDocument.${INSTANCE_FIELD}`,
+                  `$fullDocumentBeforeChange.${INSTANCE_FIELD}`,
+                ],
+              },
+              instance.instanceId,
+            ],
+          },
         },
       },
     ];

--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -226,7 +226,11 @@ export class SelectionQuery extends AggregationPipeline {
     const res = await collection.updateMany(this.getFilter(), [
       {
         $replaceWith: {
-          $mergeObjects: ["$$ROOT", this.literalizeUpdateValue(this._newValue)],
+          $mergeObjects: [
+            "$$ROOT",
+            this.literalizeUpdateValue(this._newValue),
+            { [INSTANCE_FIELD]: `$${INSTANCE_FIELD}` },
+          ],
         },
       },
     ]);

--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -9,6 +9,7 @@ import {
   DecodingContext,
   INSTANCE_FIELD,
   collectionName,
+  normalizeInstanceId,
 } from "./utils";
 
 type InstanceContext =
@@ -19,15 +20,7 @@ function resolveInstanceContext(instanceId: unknown): InstanceContext {
   if (instanceId === CROSS_INSTANCE) {
     return { kind: "cross" };
   }
-  if (instanceId === undefined || instanceId === null) {
-    return { kind: "scoped", instanceId: null };
-  }
-  if (typeof instanceId !== "string") {
-    throw new Error(
-      `Invalid instance id: expected string or CROSS_INSTANCE, got ${typeof instanceId}`,
-    );
-  }
-  return { kind: "scoped", instanceId };
+  return { kind: "scoped", instanceId: normalizeInstanceId(instanceId) };
 }
 
 function buildInitialPipeline(

--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -159,7 +159,7 @@ export class SelectionQuery extends AggregationPipeline {
     const CONFLICT_OPERATIONS: Record<string, (doc: any) => any> = {
       update: (doc) => ({
         updateOne: {
-          filter: { _id: doc._id },
+          filter: { _id: doc._id, [INSTANCE_FIELD]: doc[INSTANCE_FIELD] },
           update: [
             {
               $replaceWith: {
@@ -172,7 +172,7 @@ export class SelectionQuery extends AggregationPipeline {
       }),
       replace: (doc) => ({
         replaceOne: {
-          filter: { _id: doc._id },
+          filter: { _id: doc._id, [INSTANCE_FIELD]: doc[INSTANCE_FIELD] },
           replacement: doc,
           upsert: true,
         },

--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -1,76 +1,84 @@
 import assert from "node:assert";
 import type { QueryStage } from "@antelopejs/interface-database/common";
-import { CROSS_TENANT } from "@antelopejs/interface-database/schema";
+import { CROSS_INSTANCE } from "@antelopejs/interface-database/schema";
 import { v4 as uuidv4 } from "uuid";
 import { GetCollection } from "../../connection";
 import { AggregationPipeline } from "./pipeline";
 import { DecodeFunction, DecodeValue } from "./query";
-import { GetPhysicalStore, IsTenantScoped } from "./schema";
-import { DecodingContext, TENANT_ID_FIELD } from "./utils";
+import {
+  DecodingContext,
+  INSTANCE_FIELD,
+  collectionName,
+} from "./utils";
 
-type TenantContext =
-  | { kind: "none" }
-  | { kind: "scoped"; tenantId: string }
+type InstanceContext =
+  | { kind: "scoped"; instanceId: string | null }
   | { kind: "cross" };
 
-function resolveTenantContext(
-  schemaId: string,
-  tableName: string,
-  instanceId: unknown,
-): TenantContext {
-  if (!IsTenantScoped(schemaId, tableName)) {
-    return { kind: "none" };
-  }
-  if (instanceId === undefined) {
-    throw new Error(
-      `Table '${tableName}' is tenant-scoped: a tenant id must be provided via Schema.instance(...)`,
-    );
-  }
-  if (instanceId === CROSS_TENANT) {
+function resolveInstanceContext(instanceId: unknown): InstanceContext {
+  if (instanceId === CROSS_INSTANCE) {
     return { kind: "cross" };
+  }
+  if (instanceId === undefined || instanceId === null) {
+    return { kind: "scoped", instanceId: null };
   }
   if (typeof instanceId !== "string") {
     throw new Error(
-      `Invalid tenant id for table '${tableName}': expected string or CROSS_TENANT, got ${typeof instanceId}`,
+      `Invalid instance id: expected string or CROSS_INSTANCE, got ${typeof instanceId}`,
     );
   }
-  return { kind: "scoped", tenantId: instanceId };
+  return { kind: "scoped", instanceId };
 }
 
-function buildInitialPipeline(tenant: TenantContext): any[] {
-  if (tenant.kind === "scoped") {
-    return [{ $match: { [TENANT_ID_FIELD]: tenant.tenantId } }];
+function buildInitialPipeline(
+  instance: InstanceContext,
+  isChangeStream: boolean,
+): any[] {
+  if (instance.kind !== "scoped") {
+    return [];
   }
-  return [];
+  if (isChangeStream) {
+    return [
+      {
+        $match: {
+          $or: [
+            { [`fullDocument.${INSTANCE_FIELD}`]: instance.instanceId },
+            {
+              [`fullDocumentBeforeChange.${INSTANCE_FIELD}`]:
+                instance.instanceId,
+            },
+          ],
+        },
+      },
+    ];
+  }
+  return [{ $match: { [INSTANCE_FIELD]: instance.instanceId } }];
 }
 
 export class SelectionQuery extends AggregationPipeline {
   private _newValue: any;
   private _conflictMode?: "update" | "replace";
-  private readonly tenant: TenantContext;
-  public readonly instanceId: string | typeof CROSS_TENANT | undefined;
-  public readonly tableName: string;
+  private readonly instance: InstanceContext;
+  public readonly instanceId: string | typeof CROSS_INSTANCE | undefined;
 
   public constructor(
     schemaId: string,
-    instanceId: string | typeof CROSS_TENANT | undefined,
+    instanceId: string | typeof CROSS_INSTANCE | undefined,
     tableName: string,
     isChangeStream: boolean,
     context: DecodingContext,
   ) {
-    const tenant = resolveTenantContext(schemaId, tableName, instanceId);
-    const physicalStore = GetPhysicalStore(schemaId);
+    const instance = resolveInstanceContext(instanceId);
     super(
       schemaId,
-      physicalStore,
       tableName,
-      buildInitialPipeline(tenant),
+      collectionName(schemaId, tableName),
+      buildInitialPipeline(instance, isChangeStream),
       isChangeStream,
       context,
     );
     this.instanceId = instanceId;
-    this.tableName = tableName;
-    this.tenant = tenant;
+    this.instance = instance;
     this.resultType = "table";
   }
 
@@ -123,12 +131,12 @@ export class SelectionQuery extends AggregationPipeline {
   }
 
   private async insert() {
-    if (this.tenant.kind === "cross") {
+    if (this.instance.kind === "cross") {
       throw new Error(
-        `Insert into tenant-scoped table '${this.tableName}' requires a specific tenant id (CROSS_TENANT is read-only)`,
+        `Insert into '${this.tableName}' requires a specific instance id (CROSS_INSTANCE is read-only)`,
       );
     }
-    const collection = await GetCollection(this.database, this.collection);
+    const collection = await GetCollection(this.collection);
     const documents = this.prepareInsertDocuments();
     if (!this._conflictMode) {
       const res = await collection.insertMany(documents);
@@ -141,11 +149,11 @@ export class SelectionQuery extends AggregationPipeline {
     const documents = Array.isArray(this._newValue)
       ? this._newValue
       : [this._newValue];
+    assert(this.instance.kind === "scoped");
+    const instanceId = this.instance.instanceId;
     for (const document of documents) {
       document._id = document._id ?? uuidv4();
-      if (this.tenant.kind === "scoped") {
-        document[TENANT_ID_FIELD] = this.tenant.tenantId;
-      }
+      document[INSTANCE_FIELD] = instanceId;
     }
     return documents;
   }
@@ -217,7 +225,7 @@ export class SelectionQuery extends AggregationPipeline {
   }
 
   private async update() {
-    const collection = await GetCollection(this.database, this.collection);
+    const collection = await GetCollection(this.collection);
     const res = await collection.updateMany(this.getFilter(), [
       {
         $replaceWith: {
@@ -229,15 +237,13 @@ export class SelectionQuery extends AggregationPipeline {
   }
 
   private async replace() {
-    if (this.tenant.kind === "cross") {
+    if (this.instance.kind === "cross") {
       throw new Error(
-        `Replace on tenant-scoped table '${this.tableName}' requires a specific tenant id (CROSS_TENANT would silently strip the tenant_id from the replaced document; use update for cross-tenant mutations)`,
+        `Replace on '${this.tableName}' requires a specific instance id (CROSS_INSTANCE would strip the _instance field; use update for cross-instance mutations)`,
       );
     }
-    const collection = await GetCollection(this.database, this.collection);
-    if (this.tenant.kind === "scoped") {
-      this._newValue[TENANT_ID_FIELD] = this.tenant.tenantId;
-    }
+    const collection = await GetCollection(this.collection);
+    this._newValue[INSTANCE_FIELD] = this.instance.instanceId;
     const res = await collection.findOneAndReplace(
       this.getFilter(),
       this._newValue,
@@ -246,21 +252,21 @@ export class SelectionQuery extends AggregationPipeline {
   }
 
   private async delete() {
-    const collection = await GetCollection(this.database, this.collection);
+    const collection = await GetCollection(this.collection);
     const res = await collection.deleteMany(this.getFilter());
     return res.deletedCount;
   }
 
   public async run(): Promise<any> {
-    switch (this.resultType) {
-      case "insert":
-        return this.insert();
-      case "update":
-        return this.update();
-      case "replace":
-        return this.replace();
-      case "delete":
-        return this.delete();
+    const RUNNERS: Record<string, () => Promise<any>> = {
+      insert: () => this.insert(),
+      update: () => this.update(),
+      replace: () => this.replace(),
+      delete: () => this.delete(),
+    };
+    const runner = RUNNERS[this.resultType];
+    if (runner) {
+      return runner();
     }
     return super.run();
   }

--- a/src/implementations/database/utils.ts
+++ b/src/implementations/database/utils.ts
@@ -7,6 +7,14 @@ export const BOOKKEEPING_COLLECTION = "__antelope_instances";
 export const COLLECTION_NAME_SEPARATOR = "__";
 
 export function collectionName(schemaId: string, tableName: string): string {
+  if (
+    schemaId.includes(COLLECTION_NAME_SEPARATOR) ||
+    tableName.includes(COLLECTION_NAME_SEPARATOR)
+  ) {
+    throw new Error(
+      `schemaId and tableName may not contain "${COLLECTION_NAME_SEPARATOR}" (got schemaId="${schemaId}", tableName="${tableName}")`,
+    );
+  }
   return `${schemaId}${COLLECTION_NAME_SEPARATOR}${tableName}`;
 }
 

--- a/src/implementations/database/utils.ts
+++ b/src/implementations/database/utils.ts
@@ -2,7 +2,13 @@ import assert from "node:assert";
 import type { StagedObject } from "@antelopejs/interface-database/common";
 import { generate as randomstring } from "randomstring";
 
-export const TENANT_ID_FIELD = "tenant_id";
+export const INSTANCE_FIELD = "_instance";
+export const BOOKKEEPING_COLLECTION = "__antelope_instances";
+export const COLLECTION_NAME_SEPARATOR = "__";
+
+export function collectionName(schemaId: string, tableName: string): string {
+  return `${schemaId}${COLLECTION_NAME_SEPARATOR}${tableName}`;
+}
 
 export function Temporary(name?: string) {
   return `temporary_${name ? `${name}_` : ""}${randomstring({ capitalization: "lowercase", length: 16 })}`;

--- a/src/implementations/database/utils.ts
+++ b/src/implementations/database/utils.ts
@@ -10,6 +10,18 @@ export function collectionName(schemaId: string, tableName: string): string {
   return `${schemaId}${COLLECTION_NAME_SEPARATOR}${tableName}`;
 }
 
+export function normalizeInstanceId(id: unknown): string | null {
+  if (id === undefined || id === null || id === "") {
+    return null;
+  }
+  if (typeof id !== "string") {
+    throw new Error(
+      `Invalid instance id: expected string, got ${typeof id}`,
+    );
+  }
+  return id;
+}
+
 export function Temporary(name?: string) {
   return `temporary_${name ? `${name}_` : ""}${randomstring({ capitalization: "lowercase", length: 16 })}`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,16 @@
 import { ImplementInterface } from "@antelopejs/interface-core";
 import type { MongoClientOptions } from "mongodb";
-import { Connect, Disconnect } from "./connection";
+import { Connect, Disconnect, EnsureBookkeepingCollection } from "./connection";
 
 export interface Options {
   url: string;
+  database: string;
   options?: MongoClientOptions;
 }
 
 export async function construct(options: Options) {
-  await Connect(options?.url, options?.options);
+  await Connect(options.url, options.database, options.options);
+  await EnsureBookkeepingCollection();
 
   void ImplementInterface(
     await import("@antelopejs/interface-database/query"),

--- a/src/test/antelope.test.ts
+++ b/src/test/antelope.test.ts
@@ -21,7 +21,7 @@ export default defineConfig({
       return {
         modules: {
           local: {
-            config: { url: mongod.getUri() },
+            config: { url: mongod.getUri(), database: "antelopejs_test" },
           },
         },
       };


### PR DESCRIPTION
## Summary

Counterpart to the `@antelopejs/interface-database` revert of d6c0301. The interface goes back to **explicit `createInstance` / `destroyInstance` / `listInstances`** (no per-table `tenantScoped`, no `SchemaOptions.physicalStore`); `CROSS_TENANT` → `CROSS_INSTANCE`.

The original driver for `physicalStore` was cross-database joins. That's now solved **inside the adapter** instead of leaking into the interface:

- All schemas live in a single configurable MongoDB database (new required `database` option in module config). Cross-schema `$lookup` / `$unionWith` are now native.
- Collections are named `<schemaId>__<tableName>`.
- Per-document instance marker renamed `tenant_id` → `_instance`. Default unnamed instance stamps `_instance: null`; named instances stamp the string id.
- New `__antelope_instances` bookkeeping collection (unique index on `{ schemaId, instanceId }`) backs `createInstance` / `destroyInstance` / `listInstances`. Lifecycle handlers live in `src/implementations/database/instances.ts`.
- Collections are created with `changeStreamPreAndPostImages` enabled so the always-on `_instance` filter can match against both `fullDocument` and `fullDocumentBeforeChange` on change-stream events (incl. delete).

Removed: `collectionOwnership` tracking, `GetPhysicalStore`, `IsTenantScoped`, `assertSamePhysicalStore`, `InitializeSchemaInPhysicalStore`.

**Pre-adoption release**: ships as `1.2.0` despite breaking on-disk layout and config-shape changes (per project policy while we're still finding our footing).

## Gating

This depends on the parallel `@antelopejs/interface-database` revert PR being published first. The dep range `^0.1.0` will resolve correctly once the new interface release lands; until then, CI here will fail because the installed interface still exports `CROSS_TENANT` / `tenantScoped` / `physicalStore`. Locally verified via `pnpm link` against the unpublished interface branch.

## Migration (operators)

Existing on-disk data is **not readable post-upgrade**. A one-off migration is required:

1. Move collections from `<schemaId>` DBs into the new single configured database.
2. Rename `<tableName>` → `<schemaId>__<tableName>`.
3. Rename the `tenant_id` field on every document to `_instance` (stamp `null` if absent).
4. Optionally seed `__antelope_instances` from distinct `_instance` values per schema.

## Test plan

- [x] `pnpm build` — typecheck clean (verified locally against linked interface)
- [x] Grep sweep: no remaining `tenantScoped` / `physicalStore` / `CROSS_TENANT` / `tenant_id` / `collectionOwnership` / `GetPhysicalStore` / `IsTenantScoped` / `assertSamePhysicalStore` / `InitializeSchemaInPhysicalStore` references in `src/`
- [x] `pnpm test` against `mongo-memory-server` — **161 passing, 0 failing** locally, including:
  - `Instance Lifecycle` (createInstance/listInstances/destroyInstance)
  - `Instance Isolation` (named vs default, named vs named)
  - `CROSS_INSTANCE` (read sees all / insert rejects / update touches all / delete wipes all)
  - `Change Streams` (insert/update/delete events with the new dual-path `_instance` filter)
  - All existing `Join`, `Lookup`, `Union`, `Merge`, `Sorting`, `Filter`, `Group`, `Aggregation`, etc. suites
- [ ] CI green (gated on interface release — see above)
- [ ] Manual smoke against a real mongod with two schemas joined via `$lookup`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the per-schema-per-database layout with a single shared MongoDB database where every collection is named `<schemaId>__<tableName>`. It also renames the per-document instance marker from `tenant_id` to `_instance`, replaces `CROSS_TENANT`/`tenantScoped` with `CROSS_INSTANCE`, and introduces explicit `createInstance`/`destroyInstance`/`listInstances` lifecycle operations backed by a new `__antelope_instances` bookkeeping collection.

- All previously flagged bugs have been addressed: schema-rollback on failed init, `insertWithConflict` missing the `_instance` filter, the `$or`-based change-stream false positives (replaced by `$ifNull`), and the array-source `$lookup` dropping the instance guard (replaced by `...rightStream.initialFilter`).
- The new change-stream filter uses `$ifNull: [$fullDocument._instance, $fullDocumentBeforeChange._instance]` — correctly routing delete events through the pre-image and insert events through `fullDocument`.
- `CreateInstance` returns `\"\"` instead of `null` for the default instance; functionally harmless but semantically inconsistent with the stored `instanceId: null`.

<h3>Confidence Score: 4/5</h3>

The refactor is sound and all previously flagged bugs are resolved; the change is large and CI is gated on an unreleased interface package.

All prior issues — schema-rollback gap, $or change-stream false positives, insertWithConflict missing _instance filter, array-source $lookup dropping the instance guard — are correctly resolved. The remaining item is that CreateInstance returns "" for the default instance while null is stored, a semantic inconsistency that is harmless in practice. CI cannot be verified yet because the companion interface release has not landed.

src/implementations/database/instances.ts — the CreateInstance return value for the default instance is worth a second look before the public API hardens.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/implementations/database/instances.ts | New lifecycle file. `CreateInstance` returns `""` for the default instance while storing `instanceId: null`. `DestroyInstance` deletes data before removing the bookkeeping entry — correct order for idempotent retry. |
| src/implementations/database/selection.ts | Change-stream filter migrated from `$or` to `$ifNull`; correctly handles insert and delete events. `insertWithConflict` now includes `_instance` in both filters. `update()` preserves `_instance` via `$mergeObjects` guard. |
| src/implementations/database/pipeline.ts | Separates `initialFilter` from `pipeline`. Array-source `$lookup` now correctly prepends `...rightStream.initialFilter`. `GetIndex` calls updated to use `this.tableName`. |
| src/implementations/database/schema.ts | Simplified: removed `collectionOwnership`, `GetPhysicalStore`, `IsTenantScoped`. `register` correctly rolls back on failure. |
| src/implementations/database/utils.ts | Adds `collectionName`, `normalizeInstanceId`, and constants. `normalizeInstanceId("")` returns `null`, making the roundtrip work. |
| src/connection.ts | Centralises database name via `configuredDatabase`. `EnsureBookkeepingCollection` adds the bookkeeping collection with unique compound index. |
| src/implementations/database/query.ts | Lifecycle query handler via `tryHandleLifecycle` intercepts createInstance/destroyInstance/listInstances before `SelectionQuery.decode`. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant index.ts
    participant connection.ts
    participant schema.ts
    participant instances.ts
    participant selection.ts
    participant MongoDB

    Caller->>index.ts: "construct({ url, database })"
    index.ts->>connection.ts: Connect(url, database)
    connection.ts->>MongoDB: MongoClient.connect(url)
    index.ts->>connection.ts: EnsureBookkeepingCollection()
    connection.ts->>MongoDB: createCollection(__antelope_instances) + unique index

    Caller->>schema.ts: Schemas.register(schemaId, schema)
    schema.ts->>connection.ts: InitializeSchema(schemaId, schema)
    connection.ts->>MongoDB: createCollection(schemaId__table)
    connection.ts->>MongoDB: ensureInstanceIndex(_instance)

    Caller->>instances.ts: CreateInstance(schemaId, id)
    instances.ts->>MongoDB: upsert __antelope_instances

    Caller->>selection.ts: SelectionQuery(schemaId, instanceId, tableName)
    selection.ts->>selection.ts: buildInitialPipeline
    selection.ts->>MongoDB: aggregate / insertMany / updateMany / deleteMany

    Caller->>instances.ts: DestroyInstance(schemaId, id)
    instances.ts->>MongoDB: deleteMany per table
    instances.ts->>MongoDB: deleteOne bookkeeping

    Caller->>instances.ts: ListInstances(schemaId)
    instances.ts->>MongoDB: find __antelope_instances
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/implementations/database/selection.ts`, line 159-180 ([link](https://github.com/antelopejs/mongodb/blob/fa8e2430e95daeb307bd8cbff0d68ea6870a514a/src/implementations/database/selection.ts#L159-L180)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> `insertWithConflict` uses only `{ _id: doc._id }` as the upsert filter for both `updateOne` and `replaceOne`. In the old per-tenant collection model this was safe, but with all instances sharing a single MongoDB collection, an `_id` value that happens to collide across instances will silently overwrite the other instance's document, moving it (or its `_instance` field) to the current instance. Since `prepareInsertDocuments` already stamps `_instance` on every document, the fix is to include it in the match filter.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/implementations/database/selection.ts
   Line: 159-180

   Comment:
   `insertWithConflict` uses only `{ _id: doc._id }` as the upsert filter for both `updateOne` and `replaceOne`. In the old per-tenant collection model this was safe, but with all instances sharing a single MongoDB collection, an `_id` value that happens to collide across instances will silently overwrite the other instance's document, moving it (or its `_instance` field) to the current instance. Since `prepareInsertDocuments` already stamps `_instance` on every document, the fix is to include it in the match filter.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/implementations/database/pipeline.ts`, line 121-151 ([link](https://github.com/antelopejs/mongodb/blob/fa8e2430e95daeb307bd8cbff0d68ea6870a514a/src/implementations/database/pipeline.ts#L121-L151)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Array-source `$lookup` silently drops the `_instance` filter**

   When the FK expression is a `$map` variable (`arraySource` is set), the code builds a hand-rolled `$lookup` pipeline containing only the `$in` match; `rightStream.pipeline` — which starts with the `$match { _instance: instanceId }` filter from `buildInitialPipeline` — is discarded entirely. In the old per-tenant collection model, the foreign collection was already scoped to one tenant so the missing filter was harmless. In the new shared-collection model, the lookup will return matching rows from all instances, leaking cross-instance documents into the result set.

   The non-array-source path (line 153) correctly uses `pipeline: rightStream.pipeline`, so the fix for the array-source path is to merge the `_instance` guard into the hand-rolled pipeline, e.g. by prepending `rightStream.pipeline.slice(0, 1)` (the initial `$match`) before the `$in` stage.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/implementations/database/pipeline.ts
   Line: 121-151

   Comment:
   **Array-source `$lookup` silently drops the `_instance` filter**

   When the FK expression is a `$map` variable (`arraySource` is set), the code builds a hand-rolled `$lookup` pipeline containing only the `$in` match; `rightStream.pipeline` — which starts with the `$match { _instance: instanceId }` filter from `buildInitialPipeline` — is discarded entirely. In the old per-tenant collection model, the foreign collection was already scoped to one tenant so the missing filter was harmless. In the new shared-collection model, the lookup will return matching rows from all instances, leaking cross-instance documents into the result set.

   The non-array-source path (line 153) correctly uses `pipeline: rightStream.pipeline`, so the fix for the array-source path is to merge the `_instance` guard into the hand-rolled pipeline, e.g. by prepending `rightStream.pipeline.slice(0, 1)` (the initial `$match`) before the `$in` stage.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `src/implementations/database/pipeline.ts`, line 130-139 ([link](https://github.com/antelopejs/mongodb/blob/72a96d77dcaf90d8cb78f7aae62f4f0e8847eab2/src/implementations/database/pipeline.ts#L130-L139)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **`slice(0, 1)` guard breaks for `CROSS_INSTANCE` + `$map` joins**

   The `arraySource` path prepends `rightStream.pipeline.slice(0, 1)` under the assumption that the first pipeline element is always the `_instance` guard produced by `buildInitialPipeline`. That assumption holds only for scoped instances. When `instanceId === CROSS_INSTANCE`, `buildInitialPipeline` returns `[]`, so `rightStream.pipeline[0]` is the first user-added stage — the `$match` from the `get`/`getAll` call, which references a `$$temporary_*` variable. Injecting that stage into a `$lookup` pipeline where the variable is not in scope causes MongoDB to throw "Use of undefined variable" at runtime. A safe fix is to only prepend the slice when the right-stream's initial pipeline is non-empty (i.e., a scoped instance), and emit an empty prepend otherwise.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/implementations/database/pipeline.ts
   Line: 130-139

   Comment:
   **`slice(0, 1)` guard breaks for `CROSS_INSTANCE` + `$map` joins**

   The `arraySource` path prepends `rightStream.pipeline.slice(0, 1)` under the assumption that the first pipeline element is always the `_instance` guard produced by `buildInitialPipeline`. That assumption holds only for scoped instances. When `instanceId === CROSS_INSTANCE`, `buildInitialPipeline` returns `[]`, so `rightStream.pipeline[0]` is the first user-added stage — the `$match` from the `get`/`getAll` call, which references a `$$temporary_*` variable. Injecting that stage into a `$lookup` pipeline where the variable is not in scope causes MongoDB to throw "Use of undefined variable" at runtime. A safe fix is to only prepend the slice when the right-stream's initial pipeline is non-empty (i.e., a scoped instance), and emit an empty prepend otherwise.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/implementations/database/instances.ts:31-32
`CreateInstance` stores `instanceId: null` in the bookkeeping document but returns `""` when the caller omits or passes `null`/`undefined` for `id`. Any consumer that stores the return value and later displays or compares it will see `""` where the actual stored key is `null`. Since `normalizeInstanceId("")` maps `""` back to `null`, `destroyInstance("")` does work correctly, but the mismatch is observable: callers cannot distinguish "default instance was created" (`""`) from a potential named instance ID `""`.

```suggestion
  return instanceId;
}
```


`````

</details>

<sub>Reviews (7): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/antelopejs/mongodb/commit/1a2ef5e6edfec0ccaf25815151cb5da6ac6c42e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32829222)</sub>

<!-- /greptile_comment -->